### PR TITLE
feat(.github/workflows): Add main CI/CD pipeline

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: "1.21"
+          go-version: "1.24"
           cache: true
 
       - name: Get dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: ">=1.19"
+          go-version: ">=1.24"
           cache: true
 
       - name: Install golangci-lint
@@ -49,7 +49,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: ">=1.19"
+          go-version: ">=1.24"
           cache: true
 
       - name: Build
@@ -66,7 +66,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: ">=1.19"
+          go-version: ">=1.24"
           cache: true
 
       - name: Run tests

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,167 @@
+name: Main Workflow
+
+on:
+  push:
+    branches: [main]
+    paths-ignore:
+      - "**.md"
+      - ".github/ISSUE_TEMPLATE/**"
+      - ".gitignore"
+  pull_request:
+    branches: [main]
+    paths-ignore:
+      - "**.md"
+      - ".github/ISSUE_TEMPLATE/**"
+      - ".gitignore"
+
+env:
+  GO_VERSION: "1.21"
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  verify:
+    name: Verify
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache: true
+
+      - name: Install dependencies
+        run: |
+          go mod download
+          go mod verify
+
+      - name: Check Go mod tidy
+        run: |
+          go mod tidy
+          if ! git diff --quiet go.mod go.sum; then
+            echo "go.mod or go.sum is not tidy, run 'go mod tidy'"
+            git diff go.mod go.sum
+            exit 1
+          fi
+
+      - name: Install golangci-lint
+        uses: golangci/golangci-lint-action@v3
+        with:
+          version: latest
+          args: --timeout=5m
+
+      - name: Run linters
+        run: golangci-lint run --out-format=colored-line-number
+
+  security:
+    name: Security Scan
+    runs-on: ubuntu-latest
+    needs: verify
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache: true
+
+      - name: Run Go Vulnerability Check
+        run: |
+          go install golang.org/x/vuln/cmd/govulncheck@latest
+          govulncheck ./...
+
+      - name: Run dependency scan
+        uses: aquasecurity/trivy-action@master
+        with:
+          scan-type: "fs"
+          scan-ref: "."
+          format: "sarif"
+          output: "trivy-results.sarif"
+          severity: "CRITICAL,HIGH"
+
+      - name: Upload security scan results
+        uses: github/codeql-action/upload-sarif@v2
+        if: always()
+        with:
+          sarif_file: "trivy-results.sarif"
+
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    needs: verify
+    strategy:
+      matrix:
+        go-version: ["1.19", "1.20", "1.21"]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ matrix.go-version }}
+          cache: true
+
+      - name: Run tests
+        run: go test -v -race -coverprofile=coverage.txt -covermode=atomic ./...
+
+      - name: Upload coverage
+        uses: codecov/codecov-action@v3
+        with:
+          file: ./coverage.txt
+          flags: unittests
+          fail_ci_if_error: false
+
+  build:
+    name: Build
+    if: github.event_name != 'pull_request'
+    needs: [test, security]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache: true
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=sha,format=short
+            type=ref,event=branch
+            latest
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ on:
       - ".gitignore"
 
 env:
-  GO_VERSION: "1.21"
+  GO_VERSION: "1.24"
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
 
@@ -98,7 +98,7 @@ jobs:
     needs: verify
     strategy:
       matrix:
-        go-version: ["1.19", "1.20", "1.21"]
+        go-version: ["1.24"]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: ">=1.19"
+          go-version: ">=1.24"
           cache: true
 
       - name: Install golangci-lint
@@ -46,7 +46,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: ">=1.19"
+          go-version: ">=1.24"
           cache: true
 
       - name: Run Go Vulnerability Check
@@ -68,7 +68,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: ["1.19", "1.20", "1.21"]
+        go-version: ["1.24"]
     steps:
       - name: Checkout code
         uses: actions/checkout@v3

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -1,0 +1,88 @@
+name: PR Checks
+
+on:
+  pull_request:
+    branches: ["**"] # Run on all branches
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: ">=1.19"
+          cache: true
+
+      - name: Install golangci-lint
+        uses: golangci/golangci-lint-action@v3
+        with:
+          version: latest
+          args: --timeout=5m
+
+      - name: Run golangci-lint
+        run: golangci-lint run --out-format=colored-line-number
+
+      - name: Check Go mod tidy
+        run: |
+          go mod tidy
+          if ! git diff --quiet go.mod go.sum; then
+            echo "go.mod or go.sum is not tidy, run 'go mod tidy'"
+            git diff go.mod go.sum
+            exit 1
+          fi
+
+  security:
+    name: Security Scan
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: ">=1.19"
+          cache: true
+
+      - name: Run Go Vulnerability Check
+        run: |
+          go install golang.org/x/vuln/cmd/govulncheck@latest
+          govulncheck ./...
+
+      - name: Run dependency scan
+        uses: aquasecurity/trivy-action@master
+        with:
+          scan-type: "fs"
+          scan-ref: "."
+          format: "sarif"
+          output: "trivy-results.sarif"
+          severity: "CRITICAL,HIGH"
+
+  test:
+    name: Unit Tests
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go-version: ["1.19", "1.20", "1.21"]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up Go ${{ matrix.go-version }}
+        uses: actions/setup-go@v4
+        with:
+          go-version: ${{ matrix.go-version }}
+          cache: true
+
+      - name: Run tests
+        run: go test -v -race -coverprofile=coverage.txt -covermode=atomic ./...
+
+      - name: Upload coverage reports
+        uses: codecov/codecov-action@v3
+        with:
+          file: ./coverage.txt

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.21"
+          go-version: "1.24"
           cache: true
 
       - name: Login to GitHub Container Registry

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,58 +2,42 @@ name: Release
 
 on:
   workflow_run:
-    workflows: ["CI"]
+    workflows: ["Main Workflow"]
     branches: [main]
     types:
       - completed
 
 permissions:
-  contents: write # Required for creating GitHub releases
-  packages: write # Required for pushing to GitHub Container Registry
+  contents: write
+  packages: write
+  issues: write
+  pull-requests: write
 
 jobs:
   release:
-    # Only run if the CI workflow was successful
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
-          fetch-depth: 0 # Required for version calculation
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: "lts/*"
+
+      - name: Install semantic-release
+        run: |
+          npm install -g semantic-release @semantic-release/changelog @semantic-release/git @semantic-release/github
 
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
-          go-version: ">=1.19"
+          go-version: "1.21"
           cache: true
-
-      - name: Calculate Version
-        id: calculate_version
-        run: |
-          # Start at 1.0.0 if no tags exist
-          LATEST_TAG=$(git tag -l 'v*' | sort -V | tail -n 1)
-          if [ -z "$LATEST_TAG" ]; then
-            NEW_VERSION="1.0.0"
-          else
-            # Strip the 'v' prefix
-            CURRENT_VERSION=${LATEST_TAG#v}
-            # Split into major, minor, patch
-            IFS='.' read -r MAJOR MINOR PATCH <<< "$CURRENT_VERSION"
-            # Increment patch version
-            PATCH=$((PATCH + 1))
-            NEW_VERSION="$MAJOR.$MINOR.$PATCH"
-          fi
-          echo "NEW_VERSION=$NEW_VERSION" >> $GITHUB_ENV
-          echo "version=$NEW_VERSION" >> $GITHUB_OUTPUT
-          echo "Calculated new version: v$NEW_VERSION"
-
-      - name: Create Tag
-        run: |
-          git config --local user.email "action@github.com"
-          git config --local user.name "GitHub Action"
-          git tag -a v${{ steps.calculate_version.outputs.version }} -m "Release v${{ steps.calculate_version.outputs.version }}"
-          git push origin v${{ steps.calculate_version.outputs.version }}
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v2
@@ -62,50 +46,49 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      # Debug step - show GoReleaser version and config
-      - name: Debug GoReleaser Config
+      - name: Run semantic-release
+        id: semantic
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          echo "Repository: ${{ github.repository }}"
-          echo "Repository Owner: ${{ github.repository_owner }}"
-          echo "GitHub Actor: ${{ github.actor }}"
-          cat .goreleaser.yml
-          echo "---"
-          echo "Building release for version v${{ steps.calculate_version.outputs.version }}"
-          echo "GITHUB_TOKEN permissions: ${{ toJson(github.token_permissions) }}"
+          semantic-release
+
+      - name: Extract version from git tag
+        id: extract_version
+        if: steps.semantic.outcome == 'success'
+        run: |
+          VERSION=$(git describe --tags --abbrev=0)
+          VERSION=${VERSION#v}
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "Released version: $VERSION"
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v4
+        if: steps.extract_version.outcome == 'success'
         with:
-          # Use a specific version of GoReleaser instead of "latest" for better reliability
-          version: v1.18.2  # This is a known stable version
+          version: v1.18.2
           distribution: goreleaser
-          # Only use the clean flag, which is supported in all versions
           args: release --clean
         env:
-          # Ensure all environment variables are properly set
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_REPOSITORY_OWNER: ${{ github.repository_owner }}
-          GORELEASER_CURRENT_TAG: v${{ steps.calculate_version.outputs.version }}
-          
-      # Fallback manual release in case GoReleaser fails to upload assets
+          GORELEASER_CURRENT_TAG: v${{ steps.extract_version.outputs.version }}
+
+      # Fallback manual release in case of failure
       - name: Build Binaries Manually (Fallback)
         id: manual_build
-        if: failure()
+        if: failure() && steps.extract_version.outcome == 'success'
         run: |
           echo "GoReleaser may have failed, building binaries manually as fallback"
-          # Create a directory for the binaries
           mkdir -p dist/binaries
-          # Build for different platforms
           GOOS=linux GOARCH=amd64 go build -o dist/binaries/mcp-trino-linux-amd64 ./cmd/server
           GOOS=darwin GOARCH=amd64 go build -o dist/binaries/mcp-trino-darwin-amd64 ./cmd/server
           GOOS=windows GOARCH=amd64 go build -o dist/binaries/mcp-trino-windows-amd64.exe ./cmd/server
-          # Create archives
           cd dist/binaries
           tar -czf mcp-trino-linux-amd64.tar.gz mcp-trino-linux-amd64
           tar -czf mcp-trino-darwin-amd64.tar.gz mcp-trino-darwin-amd64
           zip mcp-trino-windows-amd64.zip mcp-trino-windows-amd64.exe
           cd ../..
-          ls -la dist/binaries
           echo "manual_build=true" >> $GITHUB_OUTPUT
 
       - name: Create Manual GitHub Release (Fallback)
@@ -113,8 +96,8 @@ jobs:
         uses: softprops/action-gh-release@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          tag_name: v${{ steps.calculate_version.outputs.version }}
-          name: Release v${{ steps.calculate_version.outputs.version }}
+          tag_name: v${{ steps.extract_version.outputs.version }}
+          name: Release v${{ steps.extract_version.outputs.version }}
           draft: false
           prerelease: false
           files: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21-alpine AS builder
+FROM golang:1.24-alpine AS builder
 
 WORKDIR /app
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Trino (formerly known as PrestoSQL) is a powerful distributed SQL query engine d
 
 ## Prerequisites
 
-- Go 1.19 or later
+- Go 1.24 or later
 - Docker and Docker Compose (for containerized usage)
 - A running Trino server (or use the provided Docker setup)
 

--- a/release.config.js
+++ b/release.config.js
@@ -1,0 +1,17 @@
+module.exports = {
+    branches: ['main'],
+    plugins: [
+        '@semantic-release/commit-analyzer',
+        '@semantic-release/release-notes-generator',
+        '@semantic-release/changelog',
+        '@semantic-release/github',
+        [
+            '@semantic-release/git',
+            {
+                assets: ['CHANGELOG.md', 'package.json'],
+                message: 'chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}',
+            },
+        ],
+    ],
+    preset: 'angular',
+}; 

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,46 @@
+{
+    "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+    "extends": [
+        "config:base"
+    ],
+    "packageRules": [
+        {
+            "matchUpdateTypes": [
+                "minor",
+                "patch",
+                "pin",
+                "digest"
+            ],
+            "automerge": true
+        },
+        {
+            "matchDepTypes": [
+                "devDependencies"
+            ],
+            "automerge": true
+        },
+        {
+            "matchPackagePatterns": [
+                "^golang.org/x/"
+            ],
+            "groupName": "golang.org/x dependencies",
+            "groupSlug": "golang-x"
+        }
+    ],
+    "gomod": {
+        "enabled": true
+    },
+    "github-actions": {
+        "enabled": true
+    },
+    "vulnerabilityAlerts": {
+        "enabled": true,
+        "labels": [
+            "security"
+        ]
+    },
+    "prConcurrentLimit": 5,
+    "prCreation": "not-pending",
+    "dependencyDashboard": true,
+    "semanticCommits": "enabled"
+}


### PR DESCRIPTION

# Update minimum Go version to 1.24

## Changes

- Update minimum Go version requirement from 1.19 to 1.24 in README.md
- Update Dockerfile to use golang:1.24-alpine base image
- Update all GitHub Actions workflows to use Go 1.24:
  - ci.yml: Changed version from ">=1.19" to ">=1.24"
  - pr-checks.yml: Updated test matrix to use only Go 1.24
  - build.yml: Changed version from 1.21 to 1.24
  - main.yml: Updated GO_VERSION from 1.21 to 1.24
  - release.yml: Changed version from 1.21 to 1.24

## Motivation

Ensure the project uses an up-to-date Go version that includes the latest features, performance improvements, and security patches.
