### PR TITLE
feat(server): add SSE server and status endpoint handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Trino (formerly PrestoSQL) is a powerful distributed SQL query engine designed f
 - ✅ Catalog, schema, and table discovery
 - ✅ Docker container support
 - ✅ Supports both STDIO and HTTP transports
+- ✅ Server-Sent Events (SSE) support for Cursor and other MCP clients
 - ✅ Compatible with Cursor, Claude Desktop, Windsurf, ChatWise, and any MCP-compatible clients.
 
 ## Installation
@@ -130,6 +131,24 @@ To use with [Cursor](https://cursor.sh/), create or edit `~/.cursor/mcp.json`:
 ```
 
 Replace the environment variables with your specific Trino configuration.
+
+For HTTP+SSE transport mode (supported for Cursor integration):
+
+```json
+{
+  "mcpServers": {
+    "mcp-trino-http": {
+      "url": "http://localhost:9097/sse"
+    }
+  }
+}
+```
+
+Then start the server in a separate terminal with:
+
+```bash
+MCP_TRANSPORT=http TRINO_HOST=<HOST> TRINO_PORT=<PORT> TRINO_USER=<USERNAME> TRINO_PASSWORD=<PASSWORD> mcp-trino
+```
 
 ### Claude Desktop
 
@@ -451,11 +470,13 @@ The server can be configured using the following environment variables:
 | TRINO_SSL_INSECURE | Allow insecure SSL            | true      |
 | MCP_TRANSPORT      | Transport method (stdio/http) | stdio     |
 | MCP_PORT           | HTTP port for http transport  | 9097      |
+| MCP_HOST           | Host for HTTP callbacks       | localhost |
 
 > **Note**: When `TRINO_SCHEME` is set to "https", `TRINO_SSL` is automatically set to true regardless of the provided value.
 
 > **Important**: The default connection mode is HTTPS. If you're using an HTTP-only Trino server, you must set `TRINO_SCHEME=http` in your environment variables.
 
+> **For Cursor Integration**: When using with Cursor, set `MCP_TRANSPORT=http` and connect to the `/sse` endpoint. The server will automatically handle SSE (Server-Sent Events) connections.
 
 ## Contributing
 

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -75,7 +75,7 @@ func main() {
 		}
 	case "http":
 		// HTTP server implementation
-		port := getEnv("MCP_PORT", "8080")
+		port := getEnv("MCP_PORT", "9097")
 		host := getEnv("MCP_HOST", "localhost")
 		addr := fmt.Sprintf(":%s", port)
 

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -78,17 +78,58 @@ func main() {
 		port := getEnv("MCP_PORT", "8080")
 		addr := fmt.Sprintf(":%s", port)
 
+		// Create SSE server for MCP
+		log.Println("Creating SSE server...")
+		sseServer := server.NewSSEServer(mcpServer, 
+			server.WithSSEEndpoint("/sse"),  // Set the SSE endpoint to /sse for Cursor
+			server.WithMessageEndpoint("/api/v1"),  // Set the message endpoint
+			server.WithKeepAlive(true),
+		)
+		log.Printf("SSE server created with endpoint: %s", sseServer.CompleteSsePath())
+		log.Printf("Message endpoint: %s", sseServer.CompleteMessagePath())
+
 		// Create an HTTP server
 		log.Printf("Starting HTTP server on %s", addr)
 		httpServer := &http.Server{
 			Addr: addr,
 			Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				log.Printf("Received request: %s %s", r.Method, r.URL.Path)
+				
+				// Set CORS headers
+				w.Header().Set("Access-Control-Allow-Origin", "*")
+				w.Header().Set("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
+				w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Accept")
+				
+				// Handle preflight OPTIONS requests
+				if r.Method == http.MethodOptions {
+					w.WriteHeader(http.StatusOK)
+					return
+				}
+				
+				// Handle SSE requests with proper content-type
+				if r.URL.Path == "/sse" {
+					log.Printf("Handling SSE request to /sse")
+					w.Header().Set("Content-Type", "text/event-stream")
+					w.Header().Set("Cache-Control", "no-cache")
+					w.Header().Set("Connection", "keep-alive")
+					sseServer.ServeHTTP(w, r)
+					return
+				}
+				
 				if r.Method == http.MethodPost && r.URL.Path == "/api/query" {
 					handleTrinoQuery(w, r, trinoClient)
 					return
 				}
+				
+				// Add a GET handler for root path
+				if r.Method == http.MethodGet && r.URL.Path == "/" {
+					handleStatus(w, r)
+					return
+				}
 
-				http.Error(w, "Not found", http.StatusNotFound)
+				// Handle all other requests
+				log.Printf("Delegating request to SSE server: %s %s", r.Method, r.URL.Path)
+				sseServer.ServeHTTP(w, r)
 			}),
 		}
 
@@ -114,6 +155,11 @@ func main() {
 
 // handleTrinoQuery handles HTTP requests for Trino queries
 func handleTrinoQuery(w http.ResponseWriter, r *http.Request, client *trino.Client) {
+	if client == nil {
+		http.Error(w, "Trino client not available", http.StatusServiceUnavailable)
+		return
+	}
+	
 	// Parse request
 	var request struct {
 		Query string `json:"query"`
@@ -202,6 +248,21 @@ func handleSignals(done chan<- bool) {
 	<-signals
 	log.Println("Received shutdown signal, shutting down...")
 	done <- true
+}
+
+// handleStatus responds to GET requests with server status
+func handleStatus(w http.ResponseWriter, r *http.Request) {
+	status := map[string]interface{}{
+		"status":  "ok",
+		"version": Version,
+		"server":  "Trino MCP Server",
+	}
+	
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(status); err != nil {
+		http.Error(w, fmt.Sprintf("Error encoding response: %v", err), http.StatusInternalServerError)
+		return
+	}
 }
 
 // getEnv retrieves an environment variable or returns a default value

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -76,17 +76,23 @@ func main() {
 	case "http":
 		// HTTP server implementation
 		port := getEnv("MCP_PORT", "8080")
+		host := getEnv("MCP_HOST", "localhost")
 		addr := fmt.Sprintf(":%s", port)
 
 		// Create SSE server for MCP
 		log.Println("Creating SSE server...")
+		baseURL := fmt.Sprintf("http://%s:%s", host, port)
 		sseServer := server.NewSSEServer(mcpServer, 
 			server.WithSSEEndpoint("/sse"),  // Set the SSE endpoint to /sse for Cursor
 			server.WithMessageEndpoint("/api/v1"),  // Set the message endpoint
 			server.WithKeepAlive(true),
+			server.WithBaseURL(baseURL),  // Explicitly set the base URL with the correct port
+			server.WithUseFullURLForMessageEndpoint(true),  // Use full URLs for message endpoints
 		)
 		log.Printf("SSE server created with endpoint: %s", sseServer.CompleteSsePath())
+		log.Printf("Full SSE endpoint URL: %s", sseServer.CompleteSseEndpoint())
 		log.Printf("Message endpoint: %s", sseServer.CompleteMessagePath())
+		log.Printf("Full Message endpoint URL: %s", sseServer.CompleteMessageEndpoint())
 
 		// Create an HTTP server
 		log.Printf("Starting HTTP server on %s", addr)


### PR DESCRIPTION

# Fix MCP server for Cursor integration

## Summary
This PR implements the necessary changes to make the Trino MCP server compatible with Cursor's MCP client implementation. The key issue was improper SSE (Server-Sent Events) endpoint configuration which caused Cursor to report "Invalid content type, expected text/event-stream" errors.

## Changes
- Added dedicated `/sse` endpoint that Cursor expects for MCP server connections
- Changed default MCP server port from 8080 to 9097 to avoid conflicts with Trino
- Added configurable host via environment variables:
  - `MCP_HOST` - Control the hostname (defaults to "localhost")
  - `MCP_PORT` - Control the port (defaults to "9097")
- Fixed message endpoint URLs to properly include host and port
- Configured proper HTTP headers for SSE protocol compliance:
  - `Content-Type: text/event-stream`
  - `Cache-Control: no-cache`
  - `Connection: keep-alive`
- Added comprehensive CORS support for cross-origin requests
- Implemented proper request routing between Trino queries and MCP server requests
- Added detailed logging for connection debugging
- Made the server resilient to Trino connection failures
- Updated README to clarify SSE support for Cursor integration

## Testing
Tested with Cursor client and verified:
- Server starts successfully even when Trino is unavailable
- SSE connections to `/sse` endpoint are properly handled
- API calls to `/api/v1` endpoint are properly routed
- Root endpoint works and returns server status
- Connection works with custom host and port settings

## Additional Notes
The server will now properly generate URLs with the configured host and port. This ensures that callbacks and session handling work properly when deploying in various environments.
