### PR TITLE
refactor(handlers): improve error handling and update dependency version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/tuannvm/mcp-trino
 go 1.24.2
 
 require (
-	github.com/mark3labs/mcp-go v0.20.0
+	github.com/mark3labs/mcp-go v0.21.0
 	github.com/trinodb/trino-go-client v0.323.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -50,8 +50,8 @@ github.com/jcmturner/gokrb5/v8 v8.4.4 h1:x1Sv4HaTpepFkXbt2IkL29DXRf8sOfZXo8eRKh6
 github.com/jcmturner/gokrb5/v8 v8.4.4/go.mod h1:1btQEpgT6k+unzCwX1KdWMEwPPkkgBtP+F6aCACiMrs=
 github.com/jcmturner/rpc/v2 v2.0.3 h1:7FXXj8Ti1IaVFpSAziCZWNzbNuZmnvw/i6CqLNdWfZY=
 github.com/jcmturner/rpc/v2 v2.0.3/go.mod h1:VUJYCIDm3PVOEHw8sgt091/20OJjskO/YJki3ELg/Hc=
-github.com/mark3labs/mcp-go v0.20.0 h1:NYZDZ10GBKHVz4SdQ2tPFSDFQFKCTrTZJLn4wj6jAaw=
-github.com/mark3labs/mcp-go v0.20.0/go.mod h1:KmJndYv7GIgcPVwEKJjNcbhVQ+hJGJhrCCB/9xITzpE=
+github.com/mark3labs/mcp-go v0.21.0 h1:oyEtiXg8PnrVEFis9b1AwbiUWF2dTbyBP5yLo7SruXE=
+github.com/mark3labs/mcp-go v0.21.0/go.mod h1:KmJndYv7GIgcPVwEKJjNcbhVQ+hJGJhrCCB/9xITzpE=
 github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY=
 github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/moby/docker-image-spec v1.3.1 h1:jMKff3w6PgbfSa69GfNg+zN/XLhfXJGnEx3Nl2EsFP0=

--- a/internal/handlers/trino_handlers.go
+++ b/internal/handlers/trino_handlers.go
@@ -27,20 +27,23 @@ func (h *TrinoHandlers) ExecuteQuery(ctx context.Context, request mcp.CallToolRe
 	// Extract the query parameter
 	query, ok := request.Params.Arguments["query"].(string)
 	if !ok {
-		return nil, fmt.Errorf("query parameter must be a string")
+		mcpErr := fmt.Errorf("query parameter must be a string")
+		return mcp.NewToolResultErrorFromErr(mcpErr.Error(), mcpErr), nil
 	}
 
 	// Execute the query
 	results, err := h.TrinoClient.ExecuteQuery(query)
 	if err != nil {
 		log.Printf("Error executing query: %v", err)
-		return nil, fmt.Errorf("query execution failed: %v", err)
+		mcpErr := fmt.Errorf("query execution failed: %w", err)
+		return mcp.NewToolResultErrorFromErr(mcpErr.Error(), mcpErr), nil
 	}
 
 	// Convert results to JSON string for display
 	jsonData, err := json.MarshalIndent(results, "", "  ")
 	if err != nil {
-		return nil, fmt.Errorf("failed to marshal results to JSON: %v", err)
+		mcpErr := fmt.Errorf("failed to marshal results to JSON: %w", err)
+		return mcp.NewToolResultErrorFromErr(mcpErr.Error(), mcpErr), nil
 	}
 
 	// Return the results as formatted JSON text
@@ -52,13 +55,15 @@ func (h *TrinoHandlers) ListCatalogs(ctx context.Context, request mcp.CallToolRe
 	catalogs, err := h.TrinoClient.ListCatalogs()
 	if err != nil {
 		log.Printf("Error listing catalogs: %v", err)
-		return nil, fmt.Errorf("failed to list catalogs: %v", err)
+		mcpErr := fmt.Errorf("failed to list catalogs: %w", err)
+		return mcp.NewToolResultErrorFromErr(mcpErr.Error(), mcpErr), nil
 	}
 
 	// Convert catalogs to JSON string for display
 	jsonData, err := json.MarshalIndent(catalogs, "", "  ")
 	if err != nil {
-		return nil, fmt.Errorf("failed to marshal catalogs to JSON: %v", err)
+		mcpErr := fmt.Errorf("failed to marshal catalogs to JSON: %w", err)
+		return mcp.NewToolResultErrorFromErr(mcpErr.Error(), mcpErr), nil
 	}
 
 	return mcp.NewToolResultText(string(jsonData)), nil
@@ -75,13 +80,15 @@ func (h *TrinoHandlers) ListSchemas(ctx context.Context, request mcp.CallToolReq
 	schemas, err := h.TrinoClient.ListSchemas(catalog)
 	if err != nil {
 		log.Printf("Error listing schemas: %v", err)
-		return nil, fmt.Errorf("failed to list schemas: %v", err)
+		mcpErr := fmt.Errorf("failed to list schemas: %w", err)
+		return mcp.NewToolResultErrorFromErr(mcpErr.Error(), mcpErr), nil
 	}
 
 	// Convert schemas to JSON string for display
 	jsonData, err := json.MarshalIndent(schemas, "", "  ")
 	if err != nil {
-		return nil, fmt.Errorf("failed to marshal schemas to JSON: %v", err)
+		mcpErr := fmt.Errorf("failed to marshal schemas to JSON: %w", err)
+		return mcp.NewToolResultErrorFromErr(mcpErr.Error(), mcpErr), nil
 	}
 
 	return mcp.NewToolResultText(string(jsonData)), nil
@@ -101,13 +108,15 @@ func (h *TrinoHandlers) ListTables(ctx context.Context, request mcp.CallToolRequ
 	tables, err := h.TrinoClient.ListTables(catalog, schema)
 	if err != nil {
 		log.Printf("Error listing tables: %v", err)
-		return nil, fmt.Errorf("failed to list tables: %v", err)
+		mcpErr := fmt.Errorf("failed to list tables: %w", err)
+		return mcp.NewToolResultErrorFromErr(mcpErr.Error(), mcpErr), nil
 	}
 
 	// Convert tables to JSON string for display
 	jsonData, err := json.MarshalIndent(tables, "", "  ")
 	if err != nil {
-		return nil, fmt.Errorf("failed to marshal tables to JSON: %v", err)
+		mcpErr := fmt.Errorf("failed to marshal tables to JSON: %w", err)
+		return mcp.NewToolResultErrorFromErr(mcpErr.Error(), mcpErr), nil
 	}
 
 	return mcp.NewToolResultText(string(jsonData)), nil
@@ -129,20 +138,23 @@ func (h *TrinoHandlers) GetTableSchema(ctx context.Context, request mcp.CallTool
 	// Table parameter is required
 	tableParam, ok := request.Params.Arguments["table"].(string)
 	if !ok {
-		return nil, fmt.Errorf("table parameter is required")
+		mcpErr := fmt.Errorf("table parameter is required")
+		return mcp.NewToolResultErrorFromErr(mcpErr.Error(), mcpErr), nil
 	}
 	table = tableParam
 
 	tableSchema, err := h.TrinoClient.GetTableSchema(catalog, schema, table)
 	if err != nil {
 		log.Printf("Error getting table schema: %v", err)
-		return nil, fmt.Errorf("failed to get table schema: %v", err)
+		mcpErr := fmt.Errorf("failed to get table schema: %w", err)
+		return mcp.NewToolResultErrorFromErr(mcpErr.Error(), mcpErr), nil
 	}
 
 	// Convert table schema to JSON string for display
 	jsonData, err := json.MarshalIndent(tableSchema, "", "  ")
 	if err != nil {
-		return nil, fmt.Errorf("failed to marshal table schema to JSON: %v", err)
+		mcpErr := fmt.Errorf("failed to marshal table schema to JSON: %w", err)
+		return mcp.NewToolResultErrorFromErr(mcpErr.Error(), mcpErr), nil
 	}
 
 	return mcp.NewToolResultText(string(jsonData)), nil


### PR DESCRIPTION
- Updates `github.com/mark3labs/mcp-go` to v0.21.0 and refactors error handling in `internal/handlers/trino_handlers.go`.

- Replaces standard Go error returns with `mcp.NewToolResultErrorFromErr(msg, err)` to align with the upstream library's standardized MCP error reporting. This improves compliance and provides better error feedback to clients.