### PR TITLE
ci(release): remove manual fallback release and update version handling

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,36 +77,6 @@ jobs:
           GITHUB_REPOSITORY_OWNER: ${{ github.repository_owner }}
           GORELEASER_CURRENT_TAG: v${{ steps.extract_version.outputs.version }}
 
-      # Fallback manual release in case of failure
-      - name: Build Binaries Manually (Fallback)
-        id: manual_build
-        if: failure() && steps.extract_version.outcome == 'success'
-        run: |
-          echo "GoReleaser may have failed, building binaries manually as fallback"
-          mkdir -p dist/binaries
-          GOOS=linux GOARCH=amd64 go build -o dist/binaries/mcp-trino-linux-amd64 ./cmd/server
-          GOOS=darwin GOARCH=amd64 go build -o dist/binaries/mcp-trino-darwin-amd64 ./cmd/server
-          GOOS=windows GOARCH=amd64 go build -o dist/binaries/mcp-trino-windows-amd64.exe ./cmd/server
-          cd dist/binaries
-          tar -czf mcp-trino-linux-amd64.tar.gz mcp-trino-linux-amd64
-          tar -czf mcp-trino-darwin-amd64.tar.gz mcp-trino-darwin-amd64
-          zip mcp-trino-windows-amd64.zip mcp-trino-windows-amd64.exe
-          cd ../..
-          echo "manual_build=true" >> $GITHUB_OUTPUT
-
-      - name: Create Manual GitHub Release (Fallback)
-        if: steps.manual_build.outputs.manual_build == 'true'
-        uses: softprops/action-gh-release@v2
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          tag_name: v${{ steps.extract_version.outputs.version }}
-          name: Release v${{ steps.extract_version.outputs.version }}
-          draft: false
-          prerelease: false
-          files: |
-            dist/binaries/mcp-trino-linux-amd64.tar.gz
-            dist/binaries/mcp-trino-darwin-amd64.tar.gz
-            dist/binaries/mcp-trino-windows-amd64.zip
 
   # Build and publish Docker image with semantic version tags
   publish-docker-image:

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -17,9 +17,10 @@ import (
 	"github.com/tuannvm/mcp-trino/internal/trino"
 )
 
-const (
-	// Version is the server version
-	Version = "0.1.0"
+// These variables will be set during the build via ldflags
+var (
+	// Version is the server version, set by the build process
+	Version = "dev"
 )
 
 func main() {

--- a/release.config.js
+++ b/release.config.js
@@ -1,7 +1,23 @@
 module.exports = {
     branches: ['main'],
     plugins: [
-        '@semantic-release/commit-analyzer',
+        [
+            '@semantic-release/commit-analyzer',
+            {
+                preset: 'angular',
+                releaseRules: [
+                    // Keep conventional commit standard rules first
+                    { type: 'feat', release: 'minor' },
+                    { type: 'fix', release: 'patch' },
+                    { type: 'perf', release: 'patch' },
+                    { type: 'docs', scope: 'README', release: 'patch' },
+                    { type: 'refactor', release: 'patch' },
+                    { type: 'chore', scope: 'deps', release: 'patch' },
+                    // Consider any changes to Go files as a patch release (fallback)
+                    { files: ['**/*.go'], release: 'patch' }
+                ]
+            }
+        ],
         '@semantic-release/release-notes-generator',
         '@semantic-release/changelog',
         '@semantic-release/github',


### PR DESCRIPTION
# Use Version Variable for Dynamic Versioning

This PR updates how the application version is managed to better integrate with our automated semantic versioning process.

## Changes

- Changed hardcoded version constant in `cmd/server/main.go` to a variable that can be set during the build process via `-ldflags`
- Set a default value of "dev" for the version during development
- Modified the `release.config.js` file to prioritize conventional commit types over file-based rules, ensuring proper semantic version increments while still guaranteeing a patch release for any Go file changes

## Why this change

The current approach uses a hardcoded version constant in the code, which:
1. Requires manual updates during releases
2. Can lead to version inconsistencies if forgotten
3. Doesn't take full advantage of our automated semantic release process

With this change:
1. Version injection happens automatically during the build process
2. GoReleaser can set the correct version in binaries
3. Developers don't need to remember to update the version
4. Semantic release rules are properly applied while still guaranteeing releases for Go code changes

## Testing

- Verified that the code builds correctly with the version variable
- Confirmed that semantic-release configuration still triggers releases appropriately
- Tested that the variable can be properly set using `-ldflags`

## Related issues

N/A