### PR TITLE
security(server): allow configurable write queries via env variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -457,24 +457,27 @@ This seamless workflow demonstrates how the MCP tools enable AI assistants to ex
 
 The server can be configured using the following environment variables:
 
-| Variable           | Description                   | Default   |
-| ------------------ | ----------------------------- | --------- |
-| TRINO_HOST         | Trino server hostname         | localhost |
-| TRINO_PORT         | Trino server port             | 8080      |
-| TRINO_USER         | Trino user                    | trino     |
-| TRINO_PASSWORD     | Trino password                | (empty)   |
-| TRINO_CATALOG      | Default catalog               | memory    |
-| TRINO_SCHEMA       | Default schema                | default   |
-| TRINO_SCHEME       | Connection scheme (http/https)| https     |
-| TRINO_SSL          | Enable SSL                    | true      |
-| TRINO_SSL_INSECURE | Allow insecure SSL            | true      |
-| MCP_TRANSPORT      | Transport method (stdio/http) | stdio     |
-| MCP_PORT           | HTTP port for http transport  | 9097      |
-| MCP_HOST           | Host for HTTP callbacks       | localhost |
+| Variable               | Description                       | Default   |
+| ---------------------- | --------------------------------- | --------- |
+| TRINO_HOST             | Trino server hostname             | localhost |
+| TRINO_PORT             | Trino server port                 | 8080      |
+| TRINO_USER             | Trino user                        | trino     |
+| TRINO_PASSWORD         | Trino password                    | (empty)   |
+| TRINO_CATALOG          | Default catalog                   | memory    |
+| TRINO_SCHEMA           | Default schema                    | default   |
+| TRINO_SCHEME           | Connection scheme (http/https)    | https     |
+| TRINO_SSL              | Enable SSL                        | true      |
+| TRINO_SSL_INSECURE     | Allow insecure SSL                | true      |
+| TRINO_ALLOW_WRITE_QUERIES | Allow non-read-only SQL queries | false     |
+| MCP_TRANSPORT          | Transport method (stdio/http)     | stdio     |
+| MCP_PORT               | HTTP port for http transport      | 9097      |
+| MCP_HOST               | Host for HTTP callbacks           | localhost |
 
 > **Note**: When `TRINO_SCHEME` is set to "https", `TRINO_SSL` is automatically set to true regardless of the provided value.
 
 > **Important**: The default connection mode is HTTPS. If you're using an HTTP-only Trino server, you must set `TRINO_SCHEME=http` in your environment variables.
+
+> **Security Note**: By default, only read-only queries (SELECT, SHOW, DESCRIBE, EXPLAIN) are allowed to prevent SQL injection. If you need to execute write operations or other non-read queries, set `TRINO_ALLOW_WRITE_QUERIES=true`, but be aware this bypasses this security protection.
 
 > **For Cursor Integration**: When using with Cursor, set `MCP_TRANSPORT=http` and connect to the `/sse` endpoint. The server will automatically handle SSE (Server-Sent Events) connections.
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"log"
 	"os"
 	"strconv"
 	"strings"
@@ -8,15 +9,16 @@ import (
 
 // TrinoConfig holds Trino connection parameters
 type TrinoConfig struct {
-	Host        string
-	Port        int
-	User        string
-	Password    string
-	Catalog     string
-	Schema      string
-	Scheme      string
-	SSL         bool
-	SSLInsecure bool
+	Host              string
+	Port              int
+	User              string
+	Password          string
+	Catalog           string
+	Schema            string
+	Scheme            string
+	SSL               bool
+	SSLInsecure       bool
+	AllowWriteQueries bool // Controls whether non-read-only SQL queries are allowed
 }
 
 // NewTrinoConfig creates a new TrinoConfig with values from environment variables or defaults
@@ -25,22 +27,29 @@ func NewTrinoConfig() *TrinoConfig {
 	ssl, _ := strconv.ParseBool(getEnv("TRINO_SSL", "true"))
 	sslInsecure, _ := strconv.ParseBool(getEnv("TRINO_SSL_INSECURE", "true"))
 	scheme := getEnv("TRINO_SCHEME", "https")
+	allowWriteQueries, _ := strconv.ParseBool(getEnv("TRINO_ALLOW_WRITE_QUERIES", "false"))
 
 	// If using HTTPS, force SSL to true
 	if strings.EqualFold(scheme, "https") {
 		ssl = true
 	}
 
+	// Log a warning if write queries are allowed
+	if allowWriteQueries {
+		log.Println("WARNING: Write queries are enabled (TRINO_ALLOW_WRITE_QUERIES=true). SQL injection protection is bypassed.")
+	}
+
 	return &TrinoConfig{
-		Host:        getEnv("TRINO_HOST", "localhost"),
-		Port:        port,
-		User:        getEnv("TRINO_USER", "trino"),
-		Password:    getEnv("TRINO_PASSWORD", ""),
-		Catalog:     getEnv("TRINO_CATALOG", "memory"),
-		Schema:      getEnv("TRINO_SCHEMA", "default"),
-		Scheme:      scheme,
-		SSL:         ssl,
-		SSLInsecure: sslInsecure,
+		Host:              getEnv("TRINO_HOST", "localhost"),
+		Port:              port,
+		User:              getEnv("TRINO_USER", "trino"),
+		Password:          getEnv("TRINO_PASSWORD", ""),
+		Catalog:           getEnv("TRINO_CATALOG", "memory"),
+		Schema:            getEnv("TRINO_SCHEMA", "default"),
+		Scheme:            scheme,
+		SSL:               ssl,
+		SSLInsecure:       sslInsecure,
+		AllowWriteQueries: allowWriteQueries,
 	}
 }
 

--- a/internal/handlers/trino_handlers.go
+++ b/internal/handlers/trino_handlers.go
@@ -31,7 +31,7 @@ func (h *TrinoHandlers) ExecuteQuery(ctx context.Context, request mcp.CallToolRe
 		return mcp.NewToolResultErrorFromErr(mcpErr.Error(), mcpErr), nil
 	}
 
-	// Execute the query
+	// Execute the query - SQL injection protection is handled within the client
 	results, err := h.TrinoClient.ExecuteQuery(query)
 	if err != nil {
 		log.Printf("Error executing query: %v", err)


### PR DESCRIPTION
Adds protection against SQL injection attacks by restricting queries to read-only operations (SELECT, SHOW, DESCRIBE, EXPLAIN, WITH) while allowing advanced users to bypass this restriction when needed.

**Changes:**
- Added `AllowWriteQueries` field to `TrinoConfig` controlled by the `TRINO_ALLOW_WRITE_QUERIES` environment variable (defaults to false)
- Implemented query validation in the `trino.Client.ExecuteQuery` method to enforce read-only operations
- Added clear warning messages when write operations are enabled
- Updated README to document the new security feature and configuration option
- Improved error handling using `NewToolResultErrorFromErr` from mcp-go v0.21.0
