### PR TITLE
Pr/nan2018/41

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,8 +92,8 @@ To use the Docker image instead of a local binary:
   "mcpServers": {
     "mcp-trino": {
       "command": "docker",
-      "args": ["run", "--rm", "-i", 
-               "-e", "TRINO_HOST=<HOST>", 
+      "args": ["run", "--rm", "-i",
+               "-e", "TRINO_HOST=<HOST>",
                "-e", "TRINO_PORT=<PORT>",
                "-e", "TRINO_USER=<USERNAME>",
                "-e", "TRINO_PASSWORD=<PASSWORD>",
@@ -469,6 +469,7 @@ The server can be configured using the following environment variables:
 | TRINO_SSL              | Enable SSL                        | true      |
 | TRINO_SSL_INSECURE     | Allow insecure SSL                | true      |
 | TRINO_ALLOW_WRITE_QUERIES | Allow non-read-only SQL queries | false     |
+| TRINO_QUERY_TIMEOUT    | Query timeout in seconds          | 30        |
 | MCP_TRANSPORT          | Transport method (stdio/http)     | stdio     |
 | MCP_PORT               | HTTP port for http transport      | 9097      |
 | MCP_HOST               | Host for HTTP callbacks           | localhost |

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"time"
 )
 
 // TrinoConfig holds Trino connection parameters
@@ -18,7 +19,8 @@ type TrinoConfig struct {
 	Scheme            string
 	SSL               bool
 	SSLInsecure       bool
-	AllowWriteQueries bool // Controls whether non-read-only SQL queries are allowed
+	AllowWriteQueries bool          // Controls whether non-read-only SQL queries are allowed
+	QueryTimeout      time.Duration // Query execution timeout
 }
 
 // NewTrinoConfig creates a new TrinoConfig with values from environment variables or defaults
@@ -28,6 +30,11 @@ func NewTrinoConfig() *TrinoConfig {
 	sslInsecure, _ := strconv.ParseBool(getEnv("TRINO_SSL_INSECURE", "true"))
 	scheme := getEnv("TRINO_SCHEME", "https")
 	allowWriteQueries, _ := strconv.ParseBool(getEnv("TRINO_ALLOW_WRITE_QUERIES", "false"))
+
+	// Parse query timeout from environment variable, default to 30 seconds
+	timeoutStr := getEnv("TRINO_QUERY_TIMEOUT", "30")
+	timeoutInt, _ := strconv.Atoi(timeoutStr)
+	queryTimeout := time.Duration(timeoutInt) * time.Second
 
 	// If using HTTPS, force SSL to true
 	if strings.EqualFold(scheme, "https") {
@@ -50,6 +57,7 @@ func NewTrinoConfig() *TrinoConfig {
 		SSL:               ssl,
 		SSLInsecure:       sslInsecure,
 		AllowWriteQueries: allowWriteQueries,
+		QueryTimeout:      queryTimeout,
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -34,7 +34,13 @@ func NewTrinoConfig() *TrinoConfig {
 	// Parse query timeout from environment variable, default to 30 seconds
 	timeoutStr := getEnv("TRINO_QUERY_TIMEOUT", "30")
 	timeoutInt, _ := strconv.Atoi(timeoutStr)
-	queryTimeout := time.Duration(timeoutInt) * time.Second
+        timeoutInt, _ := strconv.Atoi(timeoutStr)
+        // Ensure timeout is at least 1 second
+        if timeoutInt <= 0 {
+            log.Printf("WARNING: Invalid TRINO_QUERY_TIMEOUT value '%d', must be positive. Defaulting to 30 seconds", timeoutInt)
+            timeoutInt = 30
+        }
+        queryTimeout := time.Duration(timeoutInt) * time.Second
 
 	// If using HTTPS, force SSL to true
 	if strings.EqualFold(scheme, "https") {

--- a/internal/trino/client.go
+++ b/internal/trino/client.go
@@ -58,7 +58,7 @@ func NewClient(cfg *config.TrinoConfig) (*Client, error) {
 	return &Client{
 		db:      db,
 		config:  cfg,
-		timeout: 30 * time.Second, // Default timeout
+		timeout: cfg.QueryTimeout,
 	}, nil
 }
 


### PR DESCRIPTION
Fix for https://github.com/tuannvm/mcp-trino/pull/41

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the README to include the new `TRINO_QUERY_TIMEOUT` environment variable, allowing configuration of query timeout duration for the server.
  - Reformatted the Docker command example for improved clarity.
- **New Features**
  - Added support for configuring Trino query timeout via the `TRINO_QUERY_TIMEOUT` environment variable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->