### PR TITLE
Enforce Go style guide using golangci-lint

This commit introduces golangci-lint to enforce Google's Go Style Guide.

- Installed golangci-lint and configured it with rules aligned with the Google Style Guide.
- Fixed existing style violations in the codebase.
- Updated the CI workflow (.github/workflows/build.yml) to run golangci-lint on all Go files to ensure ongoing compliance.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,14 +60,14 @@ jobs:
       - name: Install golangci-lint
         uses: golangci/golangci-lint-action@v8
         with:
-          version: latest
+          version: v2.1.6 # Pinned to the version used in setup and testing
           args: --timeout=5m
           install-mode: binary
           skip-pkg-cache: true
           skip-build-cache: true
 
       - name: Run linters
-        run: golangci-lint run
+        run: golangci-lint run ./... # Explicitly run on all packages
 
   # Security vulnerability scanning and SBOM generation
   security:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,4 +1,3 @@
-# Define the configuration version
 version: "2"
 
 run:
@@ -6,4 +5,31 @@ run:
   modules-download-mode: readonly
 
 linters:
-  default: standard
+  disable-all: true # Disable all default linters first
+  enable:
+    - errcheck
+    # - gosimple # Not available in this version, functionality likely in staticcheck
+    - govet
+    - ineffassign
+    - staticcheck
+    # - stylecheck # Not available in this version, functionality likely in staticcheck/revive
+    - unconvert
+    - unused
+    - revive
+    - nolintlint
+  # no lll (line length linter) as per Google Style Guide
+  # gofmt and goimports are formatters, not linters.
+  # golangci-lint handles them separately.
+
+# I might need to add configuration for specific linters later if the output is too noisy
+# or if specific Google Style Guide points need more targeted rules.
+# Particularly, 'revive' might need configuration for stricter Google Style alignment.
+
+# For now, default settings for the enabled linters will be used.
+
+issues:
+  # Exclude known issues or specific paths if necessary after first run
+  # exclude-rules:
+  #   - path: _test\.go
+  #     linters:
+  #       - dupl

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -1,3 +1,5 @@
+// Package main implements the Trino MCP server and provides
+// HTTP and STDIO interfaces for interacting with Trino via MCP.
 package main
 
 import (
@@ -177,7 +179,7 @@ func handleSignals(done chan<- bool) {
 	done <- true
 }
 
-func handleStatus(w http.ResponseWriter, r *http.Request) {
+func handleStatus(w http.ResponseWriter, _ *http.Request) {
 	status := map[string]string{"status": "ok", "version": Version}
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(status)

--- a/examples/test_query.go
+++ b/examples/test_query.go
@@ -1,3 +1,5 @@
+// Package main executes test queries against the Trino server
+// and demonstrates basic client functionality.
 package main
 
 import (

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,3 +1,5 @@
+// Package config provides configuration handling for the Trino connector,
+// including Trino server connection parameters and query execution settings.
 package config
 
 import (

--- a/internal/handlers/trino_handlers.go
+++ b/internal/handlers/trino_handlers.go
@@ -1,3 +1,6 @@
+// Package handlers provides MCP tool handlers for interacting with Trino.
+// It defines methods for executing queries, listing catalogs, schemas, tables,
+// and retrieving table schemas.
 package handlers
 
 import (
@@ -23,7 +26,7 @@ func NewTrinoHandlers(client *trino.Client) *TrinoHandlers {
 }
 
 // ExecuteQuery handles query execution
-func (h *TrinoHandlers) ExecuteQuery(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+func (h *TrinoHandlers) ExecuteQuery(_ context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	// Extract the query parameter
 	query, ok := request.Params.Arguments["query"].(string)
 	if !ok {
@@ -51,7 +54,7 @@ func (h *TrinoHandlers) ExecuteQuery(ctx context.Context, request mcp.CallToolRe
 }
 
 // ListCatalogs handles catalog listing
-func (h *TrinoHandlers) ListCatalogs(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+func (h *TrinoHandlers) ListCatalogs(_ context.Context, _ mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	catalogs, err := h.TrinoClient.ListCatalogs()
 	if err != nil {
 		log.Printf("Error listing catalogs: %v", err)
@@ -70,7 +73,7 @@ func (h *TrinoHandlers) ListCatalogs(ctx context.Context, request mcp.CallToolRe
 }
 
 // ListSchemas handles schema listing
-func (h *TrinoHandlers) ListSchemas(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+func (h *TrinoHandlers) ListSchemas(_ context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	// Extract catalog parameter (optional)
 	var catalog string
 	if catalogParam, ok := request.Params.Arguments["catalog"].(string); ok {
@@ -95,7 +98,7 @@ func (h *TrinoHandlers) ListSchemas(ctx context.Context, request mcp.CallToolReq
 }
 
 // ListTables handles table listing
-func (h *TrinoHandlers) ListTables(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+func (h *TrinoHandlers) ListTables(_ context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	// Extract catalog and schema parameters (optional)
 	var catalog, schema string
 	if catalogParam, ok := request.Params.Arguments["catalog"].(string); ok {
@@ -123,7 +126,7 @@ func (h *TrinoHandlers) ListTables(ctx context.Context, request mcp.CallToolRequ
 }
 
 // GetTableSchema handles table schema retrieval
-func (h *TrinoHandlers) GetTableSchema(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+func (h *TrinoHandlers) GetTableSchema(_ context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	// Extract parameters
 	var catalog, schema string
 	var table string

--- a/internal/trino/client.go
+++ b/internal/trino/client.go
@@ -1,3 +1,5 @@
+// Package trino provides a client for interacting with a Trino server,
+// including query execution and metadata retrieval.
 package trino
 
 import (
@@ -9,7 +11,7 @@ import (
 	"strings"
 	"time"
 
-	_ "github.com/trinodb/trino-go-client/trino"
+	_ "github.com/trinodb/trino-go-client/trino" // Register Trino database driver
 	"github.com/tuannvm/mcp-trino/internal/config"
 )
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added package-level comments throughout the codebase to clarify the purpose of various packages and files.
  - Enhanced configuration file comments to explain enabled linters and future customization options.

- **Refactor**
  - Updated several method and function signatures to ignore unused parameters for improved code clarity.

- **Chores**
  - Updated linter configuration to explicitly specify enabled linters and added explanatory comments.
  - Pinned the linter version in the workflow for consistent results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->