### PR TITLE
fix: upgrade Go version to 1.24.6 to resolve GO-2025-3849 vulnerability

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/tuannvm/mcp-trino
 
-go 1.24.2
+go 1.24.6
 
 require (
 	github.com/coreos/go-oidc/v3 v3.14.1


### PR DESCRIPTION
Fixes #76

Upgrades Go version from 1.24.2 to 1.24.6 to resolve the GO-2025-3849 security vulnerability in database/sql package.

**Changes:**
- Updated go.mod to use Go 1.24.6
- Resolves vulnerability affecting Rows.Scan in internal/trino/client.go

**Vulnerability Details:**
- GO-2025-3849: Incorrect results returned from Rows.Scan in database/sql
- Fixed in database/sql@go1.24.6

Generated with [Claude Code](https://claude.ai/code)