### PR TITLE
feat(oauth): add redirect URIs for mcp-remote compatibility

### DIFF
--- a/internal/oauth/metadata.go
+++ b/internal/oauth/metadata.go
@@ -94,6 +94,11 @@ func (h *OAuth2Handler) HandleAuthorizationServerMetadata(w http.ResponseWriter,
 		"revocation_endpoint":                   fmt.Sprintf("%s/oauth/revoke", h.config.MCPURL),
 	}
 
+	// Add redirect URIs for mcp-remote compatibility
+	if h.config.RedirectURI != "" {
+		metadata["redirect_uris"] = []string{h.config.RedirectURI}
+	}
+
 	// Encode and send response
 	w.WriteHeader(http.StatusOK)
 	if err := json.NewEncoder(w).Encode(metadata); err != nil {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Authorization Server Metadata now conditionally includes a redirect_uris field when a Redirect URI is configured, exposing the configured value in discovery responses.
  * Output of the metadata endpoint is updated only when a Redirect URI is set; environments without one are unchanged.
  * No other metadata fields, behaviors, authentication flows, or error handling are affected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->