### PR TITLE
Fix nil pointer dereference when OAuth is disabled

### DIFF
--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -158,6 +158,18 @@ func (s *Server) ServeHTTP(port string) error {
 		keyFile := getEnv("HTTPS_KEY_FILE", "")
 		oauth2Config := s.oauthHandler.GetConfig()
 
+		var oauth2Config *oauth.OAuth2Config
+		if s.oauthHandler != nil {
+			oauth2Config = s.oauthHandler.GetConfig()
+		} else {
+			mcpHost := getEnv("MCP_HOST", "localhost")
+			mcpPort := getEnv("MCP_PORT", "8080")
+			mcpURL := getEnv("MCP_URL", fmt.Sprintf("http://%s:%s", mcpHost, mcpPort))
+			oauth2Config = &oauth.OAuth2Config{
+				MCPURL: mcpURL,
+			}
+		}
+
 		if certFile != "" && keyFile != "" {
 			// Start HTTPS server
 			oauthStatus := s.getOAuthStatus()

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -156,7 +156,6 @@ func (s *Server) ServeHTTP(port string) error {
 		// Check for HTTPS certificates
 		certFile := getEnv("HTTPS_CERT_FILE", "")
 		keyFile := getEnv("HTTPS_KEY_FILE", "")
-		oauth2Config := s.oauthHandler.GetConfig()
 
 		var oauth2Config *oauth.OAuth2Config
 		if s.oauthHandler != nil {


### PR DESCRIPTION
### Problem

When running the MCP server with `TRINO_OAUTH_ENABLED=false`, the server would crash with a nil pointer dereference panic in ServeHTTP(). The code was unconditionally calling s.oauthHandler.GetConfig() even when OAuth was disabled and the handler was nil.

### Solution
Added a nil check before accessing the OAuth handler in internal/mcp/server.go. When OAuth is disabled, we now create a minimal fallback config for logging purposes instead of dereferencing a nil pointer.

#### Reproduction

```
TRINO_HOST=<MY_TRINO_HOST> TRINO_PORT=443 TRINO_USER=my-mcp TRINO_OAUTH_ENABLED=false MCP_TRANSPORT=http ./bin/mcp-trino
2025/09/15 16:17:49 Starting Trino MCP Server...
2025/09/15 16:17:49 Loading Trino configuration...
2025/09/15 16:17:49 Connecting to Trino server...
2025/09/15 16:17:49 Testing Trino connection...
2025/09/15 16:17:49 Connected to Trino server. Available catalogs: jmx, nu, system
2025/09/15 16:17:49 Initializing MCP server...
2025/09/15 16:17:49 OAuth authentication disabled
2025/09/15 16:17:49 Starting MCP server with http transport...
2025/09/15 16:17:49 Setting up StreamableHTTP server...
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x0 pc=0x1033237b4]

goroutine 13 [running]:
github.com/tuannvm/mcp-trino/internal/oauth.(*OAuth2Handler).GetConfig(...)
	/Users/otavio.valadares/dev/nu/mcp-trino/internal/oauth/handlers.go:31
github.com/tuannvm/mcp-trino/internal/mcp.(*Server).ServeHTTP.func2()
	/Users/otavio.valadares/dev/nu/mcp-trino/internal/mcp/server.go:159 +0x74
created by github.com/tuannvm/mcp-trino/internal/mcp.(*Server).ServeHTTP in goroutine 1
	/Users/otavio.valadares/dev/nu/mcp-trino/internal/mcp/server.go:155 +0x660
```