### PR TITLE
fix(oidc): add explicit audience validation in token claims validation

### DIFF
--- a/internal/oauth/providers.go
+++ b/internal/oauth/providers.go
@@ -135,6 +135,13 @@ func (v *HMACValidator) validateAudience(claims jwt.MapClaims) error {
 
 // Initialize sets up the OIDC validator with provider discovery
 func (v *OIDCValidator) Initialize(cfg *config.TrinoConfig) error {
+	if cfg.OIDCIssuer == "" {
+		return fmt.Errorf("OIDC issuer is required for OIDC provider")
+	}
+	if cfg.OIDCAudience == "" {
+		return fmt.Errorf("OIDC audience is required for OIDC provider")
+	}
+
 	// Use standard library context with timeout
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
@@ -165,9 +172,9 @@ func (v *OIDCValidator) Initialize(cfg *config.TrinoConfig) error {
 	
 	// Configure token verifier with required validation settings
 	verifier := provider.Verifier(&oidc.Config{
-		ClientID:             cfg.OIDCAudience,
+		ClientID:             cfg.OIDCClientID,
 		SupportedSigningAlgs: []string{oidc.RS256, oidc.ES256},
-		SkipClientIDCheck:    false, // Verify audience
+		SkipClientIDCheck:    false, // Always validate if ClientID is provided
 		SkipExpiryCheck:      false, // Verify expiration
 		SkipIssuerCheck:      false, // Verify issuer
 	})

--- a/internal/oauth/providers_test.go
+++ b/internal/oauth/providers_test.go
@@ -324,3 +324,51 @@ func TestOIDCValidator_AudienceValidation(t *testing.T) {
 	}
 }
 
+// TestOIDCValidator_InitializationValidation tests OIDC initialization validation
+func TestOIDCValidator_InitializationValidation(t *testing.T) {
+	tests := []struct {
+		name        string
+		config      *config.TrinoConfig
+		expectError bool
+		errorMsg    string
+	}{
+		{
+			name: "missing issuer",
+			config: &config.TrinoConfig{
+				OIDCIssuer:   "",
+				OIDCAudience: "test-audience",
+			},
+			expectError: true,
+			errorMsg:    "OIDC issuer is required for OIDC provider",
+		},
+		{
+			name: "missing audience",
+			config: &config.TrinoConfig{
+				OIDCIssuer:   "https://example.com",
+				OIDCAudience: "",
+			},
+			expectError: true,
+			errorMsg:    "OIDC audience is required for OIDC provider",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			validator := &OIDCValidator{}
+			err := validator.Initialize(tt.config)
+
+			if tt.expectError {
+				if err == nil {
+					t.Errorf("Expected error but got none")
+				} else if tt.errorMsg != "" && err.Error() != tt.errorMsg {
+					t.Errorf("Expected error message '%s', got '%s'", tt.errorMsg, err.Error())
+				}
+			} else {
+				if err != nil {
+					t.Errorf("Unexpected error: %v", err)
+				}
+			}
+		})
+	}
+}
+


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added configurable audience validation for OIDC tokens (supports single or multiple aud values) and explicit initialization checks for issuer and audience.
- Bug Fixes
  - Tokens with missing or mismatched audience are now rejected with clearer errors.
  - Improved OIDC provider discovery reliability using a hardened HTTP client (TLS and timeout safeguards).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->