### PR TITLE
Strip trailing semicolon from SQL query before considering the semicolon an injection risk

### DIFF
--- a/internal/trino/client.go
+++ b/internal/trino/client.go
@@ -154,6 +154,9 @@ func sanitizeQueryForKeywordDetection(query string) string {
 
 // ExecuteQuery executes a SQL query and returns the results
 func (c *Client) ExecuteQuery(query string) ([]map[string]interface{}, error) {
+	// Strip trailing semicolon that Trino doesn't allow
+	query = strings.TrimSuffix(strings.TrimSpace(query), ";")
+
 	// SQL injection protection: only allow read-only queries unless explicitly allowed in config
 	if !c.config.AllowWriteQueries && !isReadOnlyQuery(query) {
 		return nil, fmt.Errorf("security restriction: only SELECT, SHOW, DESCRIBE, and EXPLAIN queries are allowed. " +


### PR DESCRIPTION
Implements the fix I proposed in #114. 

(Actually, I hadn't realized Trino didn't allow semicolons, so I had to move the stripping to the actual query, not just the string that's validated as read only.)

Happy to discuss or make changes as desired.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved query handling by ignoring trailing semicolons, reducing errors when submitting read-only queries.
  * Enhanced compatibility with Trino by normalizing queries before validation.
  * Provides more consistent behavior across different query inputs, leading to fewer false rejections and smoother execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->