### PR TITLE
fix(query): use state machine for SQL comment/string parsing

### DIFF
--- a/internal/trino/client.go
+++ b/internal/trino/client.go
@@ -331,20 +331,6 @@ func sanitizeQueryForKeywordDetection(query string) string {
 			continue
 		}
 
-		// Check for backtick-quoted identifier
-		if query[i] == '`' {
-			result.WriteString("`IDENTIFIER`")
-			i++
-			// Skip until closing backtick
-			for i < n && query[i] != '`' {
-				i++
-			}
-			if i < n {
-				i++ // skip closing backtick
-			}
-			continue
-		}
-
 		// Regular character - copy to output
 		result.WriteByte(query[i])
 		i++

--- a/internal/trino/comment_test.go
+++ b/internal/trino/comment_test.go
@@ -104,8 +104,8 @@ SELECT * FROM "table"`,
 			expected: true,
 		},
 		{
-			name: "Backticks in comment",
-			query: "-- Use `backticks` for identifiers\nSELECT * FROM `table`",
+			name: "Backticks in comment (Trino uses double quotes, not backticks)",
+			query: "-- Use `backticks` for identifiers\nSELECT * FROM \"table\"",
 			expected: true,
 		},
 		{


### PR DESCRIPTION
## Fix SQL Comment/String Parsing with State Machine

Replaces regex-based comment removal with a proper state machine parser to fix two related bugs in query validation:

### Problems

1. **Apostrophes in comments** (`DON'T`, `won't`, `it's`) were misinterpreted as string literal delimiters, causing valid read queries to be incorrectly rejected as write operations.

2. **Comment markers inside strings** (`--`, `/* */`) were incorrectly treated as actual comments, corrupting queries:
   ```sql
   SELECT * FROM table WHERE msg = '-- test' OR id = 1
   ```
   became:
   ```sql
   SELECT * FROM table WHERE msg = '
   ```

### Solution

Implemented a character-by-character state machine that correctly tracks parser state (inside string vs comment) and handles:
- SQL escape sequences (`''`, `""`)
- Comment markers inside strings (treated as literal, not comments)
- Apostrophes inside comments (stripped, not string delimiters)
- Single-line (`--`) and multi-line (`/* */`) comments
- Newline consumption and unclosed comment handling

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved query sanitization used for read-only detection: comments are stripped and string/identifier literals are neutralized to reduce false positives/negatives for write-operation detection.

* **Tests**
  * Added comprehensive tests covering single-line/multi-line comments, inline comments, and string/quoted-literal edge cases for read-only detection.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->