### PR TITLE
feat: Add MCP tool annotations for LLM guidance

### DIFF
--- a/internal/mcp/handlers.go
+++ b/internal/mcp/handlers.go
@@ -287,10 +287,10 @@ func (h *TrinoHandlers) ExplainQuery(ctx context.Context, request mcp.CallToolRe
 func RegisterTrinoTools(m *server.MCPServer, h *TrinoHandlers) {
 
 	m.AddTool(mcp.NewTool("execute_query",
-		mcp.WithDescription("Execute SQL queries on Trino's fast distributed query engine for big data analytics. Supports all SQL statements including SELECT, INSERT, UPDATE, DELETE, CREATE, DROP, and other DML/DDL operations across multiple data sources simultaneously. Perfect for complex analytics, aggregations, joins, data manipulation, and cross-system data exploration on large datasets."),
+		mcp.WithDescription("Execute SQL queries on Trino's fast distributed query engine for big data analytics. By default, only read-only queries (SELECT, SHOW, DESCRIBE, EXPLAIN) are allowed for security. When TRINO_ALLOW_WRITE_QUERIES=true is set, supports all SQL statements including INSERT, UPDATE, DELETE, CREATE, DROP, and other DML/DDL operations. Perfect for complex analytics, aggregations, joins, and cross-system data exploration on large datasets."),
 		mcp.WithTitleAnnotation("Execute Query"),
 		mcp.WithDestructiveHintAnnotation(true),
-		mcp.WithString("query", mcp.Required(), mcp.Description("SQL query to execute on Trino cluster (supports all SQL statements including DML and DDL)")),
+		mcp.WithString("query", mcp.Required(), mcp.Description("SQL query to execute. By default read-only queries only; DML/DDL requires TRINO_ALLOW_WRITE_QUERIES=true")),
 	), h.ExecuteQuery)
 
 	m.AddTool(mcp.NewTool("list_catalogs",


### PR DESCRIPTION
## Summary

Add title and hint annotations to all 6 Trino tools to help LLMs understand tool behavior and make safer decisions about tool usage.

- Added `WithTitleAnnotation()` for human-readable tool names
- Added `WithReadOnlyHintAnnotation(true)` for 5 read-only tools
- Added `WithDestructiveHintAnnotation(true)` for 1 state-modifying tool

### Tool Classification

**Read-Only Tools (5 tools):**
| Tool | Title | Description |
|------|-------|-------------|
| `list_catalogs` | List Catalogs | Discover Trino catalogs |
| `list_schemas` | List Schemas | Browse schemas in catalog |
| `list_tables` | List Tables | Discover tables and views |
| `get_table_schema` | Get Table Schema | Inspect table structure |
| `explain_query` | Explain Query | Analyze query execution plans |

**Destructive Tools (1 tool):**
| Tool | Title | Description |
|------|-------|-------------|
| `execute_query` | Execute Query | Execute SQL (can run DML/DDL) |

### Why This Matters

MCP tool annotations help LLMs:
1. **Display better UI** - Title annotations provide human-readable names
2. **Make safer decisions** - Hint annotations indicate which tools modify state
3. **Request appropriate confirmation** - Destructive hints trigger user confirmation flows

## Test plan

- [x] `go build ./...` compiles successfully
- [ ] Run MCP server and verify annotations appear in tool listings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Added clear titles and action hints for query-related tools (e.g., "List Catalogs", "Get Table Schema", "Explain Query", "Execute Query") and explicit Read-Only/Destructive indicators for improved UI clarity.
* **Documentation**
  * Expanded tool descriptions to state default read-only behavior and that write queries are allowed only when explicitly enabled; clarified supported SQL/parameter behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->