### PR TITLE
fix: strip default port from Host header to prevent proxy 503 errors

### DIFF
--- a/internal/trino/client.go
+++ b/internal/trino/client.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"fmt"
 	"log"
+	"net"
 	"net/http"
 	"net/url"
 	"regexp"
@@ -31,6 +32,18 @@ type headerRoundTripper struct {
 
 func (t *headerRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	req = req.Clone(req.Context())
+
+	// Strip default port from Host header to avoid proxy routing issues.
+	// Go's HTTP client includes the port in the Host header even for default
+	// ports (80/443), but some reverse proxies and load balancers don't
+	// recognize "host:80" as equivalent to "host", returning 503.
+	if host := req.URL.Host; host != "" {
+		hostname, port, err := net.SplitHostPort(host)
+		if err == nil && ((req.URL.Scheme == "http" && port == "80") || (req.URL.Scheme == "https" && port == "443")) {
+			req.URL.Host = hostname
+			req.Host = hostname
+		}
+	}
 
 	// Set X-Trino-Source header for query attribution
 	if t.config.TrinoSource != "" {


### PR DESCRIPTION
Go's HTTP client includes the port in the Host header even for default ports (e.g. Host: example.com:80). Some reverse proxies and load balancers don't recognize "host:80" as equivalent to "host" and return 503 Service Unavailable.

This is compounded by a bug in trino-go-client where the retry loop on 503 reuses the consumed request body, resulting in the misleading error: "http: ContentLength=N with Body length 0"

The fix strips :80 (http) and :443 (https) from the Host header in the custom roundtripper before forwarding the request.

## Summary
<!-- What does this PR do? -->

## Changes
-

## Testing
- [ ] Tests pass locally
- [ ] New tests added (if applicable)

## Related Issues
<!-- Fixes #123 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed handling of default ports in host headers for HTTP and HTTPS client connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->