### PR TITLE
docs: add Fronteir AI hosted deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ This project implements a Model Context Protocol (MCP) server for Trino in Go. I
 
 Trino (formerly PrestoSQL) is a powerful distributed SQL query engine designed for fast analytics on large datasets.
 
+## Hosted deployment
+
+A hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/tuannvm-mcp-trino).
+
 ## Architecture
 
 ```mermaid


### PR DESCRIPTION
Love the project!

Adds a short note in the README that a hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/tuannvm-mcp-trino).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added "Hosted deployment" section to README with information about accessing a hosted instance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->