### PR TITLE
fix(handlers): add workaround for empty object schema properties

### DIFF
--- a/internal/mcp/handlers.go
+++ b/internal/mcp/handlers.go
@@ -305,7 +305,7 @@ func RegisterTrinoTools(m *server.MCPServer, h *TrinoHandlers) {
 		mcp.WithString("query", mcp.Required(), mcp.Description("SQL query to execute. By default read-only queries only; DML/DDL requires TRINO_ALLOW_WRITE_QUERIES=true")),
 	), h.ExecuteQuery)
 
-	m.AddTool(mcp.NewTool("list_catalogs",
+	m.AddTool(newNoArgTool("list_catalogs",
 		mcp.WithDescription("Discover available Trino catalogs - each catalog represents a connector to different data systems (PostgreSQL, MySQL, S3, HDFS, Kafka, etc.). Catalogs are your entry point to querying data across heterogeneous systems in a single SQL query."),
 		mcp.WithTitleAnnotation("List Catalogs"),
 		mcp.WithReadOnlyHintAnnotation(true)),
@@ -342,4 +342,13 @@ func RegisterTrinoTools(m *server.MCPServer, h *TrinoHandlers) {
 		mcp.WithString("query", mcp.Required(), mcp.Description("SQL query to analyze (SELECT, JOIN, aggregations, etc.)")),
 		mcp.WithString("format", mcp.Description("Plan type: LOGICAL, DISTRIBUTED, VALIDATE, or IO (optional)"))),
 		h.ExplainQuery)
+}
+
+// Workaround for mcp-go v0.43.1 - https://github.com/mark3labs/mcp-go/issues/694
+// TODO: Remove this workaround when bumping mcp-go dependency
+func newNoArgTool(name string, opts ...mcp.ToolOption) mcp.Tool {
+	tool := mcp.NewTool(name, opts...)
+	tool.InputSchema = mcp.ToolInputSchema{}
+	tool.RawInputSchema = json.RawMessage(`{"type":"object","properties":{}}`)
+	return tool
 }


### PR DESCRIPTION
## Summary
This PR resolves a compatibility issue with strict MCP clients like GitHub Copilot. Copilot rejects tool registrations and throws a `400 Invalid schema` error if a tool with no arguments has an input schema missing the `properties` field. 

Since the underlying `mcp-go` library currently omits this field for empty schemas, this PR introduces a workaround to manually inject `{"properties": {}}` into the raw JSON schema, allowing seamless integration with Copilot.

## Changes
- Added a `newNoArgTool` helper function that overrides `RawInputSchema` to explicitly include empty properties.
- Updated the initialization of no-argument tool (`list_catalogs`) to use this new helper function instead of `mcp.NewTool`.

## Testing
- [x] Tests pass locally
- [ ] New tests added (if applicable)

## Related Issues
- https://github.com/mark3labs/mcp-go/issues/694

## Note
Since [the previous PR](https://github.com/tuannvm/mcp-trino/pull/172) was closed, I've opened a new one.
I've addressed the feedback from the previous PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed input schema handling for tools that accept no arguments, ensuring consistent validation across the system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->