### PR TITLE
feat: merge Vungle per-query user identity (PE-7844)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ permissions:
   checks: write
 
 env:
-  GO_VERSION: "1.25.8"
+  GO_VERSION: "1.25.9"
   REGISTRY: ghcr.io
 
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ permissions:
   packages: write
 
 env:
-  GO_VERSION: "1.25.8"
+  GO_VERSION: "1.25.9"
   REGISTRY: ghcr.io
 
 jobs:

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ARG TARGETPLATFORM
 ARG TARGETOS
 ARG TARGETARCH
 
-FROM --platform=$BUILDPLATFORM golang:1.25.8-alpine AS builder
+FROM --platform=$BUILDPLATFORM golang:1.25.9-alpine AS builder
 
 WORKDIR /app
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/tuannvm/mcp-trino
 
-go 1.25.8
+go 1.25.9
 
 require (
 	github.com/mark3labs/mcp-go v0.43.1

--- a/internal/trino/client.go
+++ b/internal/trino/client.go
@@ -278,23 +278,28 @@ func sanitizeQueryForKeywordDetection(query string) string {
 	return strings.TrimSpace(query)
 }
 
-// getQueryUsername returns the username of the user executing the query if present in OAuth context
-// This is used for query attribution (X-Trino-Client-Tags/Info) independent of impersonation
-func getQueryUsername(ctx context.Context) string {
+// defaultAttributionUser is the fallback username used for query attribution
+// when no OAuth user identity is available.
+const defaultAttributionUser = "mcp-trino-user"
+
+// getOAuthUserAndUsername returns the OAuth user (if any) and the display username
+// from context. This avoids redundant context lookups.
+func getOAuthUserAndUsername(ctx context.Context) (*oauth.User, string) {
 	user, exists := oauth.GetUserFromContext(ctx)
 	if !exists || user == nil {
-		return ""
+		return nil, defaultAttributionUser
 	}
-	if user.Username != "" {
-		return user.Username
+	username := user.Username
+	if username == "" {
+		username = user.Email
 	}
-	if user.Email != "" {
-		return user.Email
+	if username == "" {
+		username = user.Subject
 	}
-	if user.Subject != "" {
-		return user.Subject
+	if username == "" {
+		username = defaultAttributionUser
 	}
-	return ""
+	return user, username
 }
 
 // QueryResult holds query results along with metadata about truncation.
@@ -331,18 +336,26 @@ func (c *Client) ExecuteQueryWithContext(ctx context.Context, query string) (*Qu
 	queryCtx, cancel := context.WithTimeout(ctx, c.timeout)
 	defer cancel()
 
-	// Build query arguments for attribution headers
-	// These are complementary to the X-Trino-User header set by RoundTripper
-	var queryArgs []interface{}
-	if userName := getQueryUsername(ctx); userName != "" {
-		queryArgs = append(queryArgs,
-			sql.Named("X-Trino-Client-Tags", userName),
-			sql.Named("X-Trino-Client-Info", userName),
-		)
-		// Only set X-Trino-Source if not already configured globally
-		if c.config.TrinoSource == "" {
-			queryArgs = append(queryArgs, sql.Named("X-Trino-Source", userName))
+	// Build query arguments for per-query user identity and attribution
+	// These are passed as NamedArgs to the Trino driver, which uses them to set
+	// session properties regardless of the authentication method.
+	_, userName := getOAuthUserAndUsername(ctx)
+	queryArgs := []interface{}{
+		sql.Named("X-Trino-Client-Tags", userName),
+		sql.Named("X-Trino-Client-Info", userName),
+	}
+	// When impersonation is enabled, use the impersonated user from context
+	// (set by prepareImpersonationContext which respects ImpersonationField config)
+	// for X-Trino-User instead of the raw OAuth username, ensuring the correct
+	// identity is forwarded to Trino.
+	if c.config.EnableImpersonation {
+		if impersonatedUser, ok := GetImpersonatedUser(ctx); ok && impersonatedUser != "" {
+			queryArgs = append(queryArgs, sql.Named("X-Trino-User", impersonatedUser))
 		}
+	}
+	// Only override X-Trino-Source via NamedArg if not already configured globally
+	if c.config.TrinoSource == "" {
+		queryArgs = append(queryArgs, sql.Named("X-Trino-Source", userName))
 	}
 
 	// Execute the query with optional attribution headers

--- a/internal/trino/client_test.go
+++ b/internal/trino/client_test.go
@@ -594,41 +594,41 @@ func TestMaxRowsConfigPropagation(t *testing.T) {
 	}
 }
 
-func TestGetQueryUsername(t *testing.T) {
+func TestGetOAuthUserAndUsername(t *testing.T) {
 	tests := []struct {
-		name     string
-		user     *oauth.User
-		expected string
+		name         string
+		user         *oauth.User
+		expectedName string
 	}{
 		{
-			name:     "User with email",
-			user:     &oauth.User{Email: "abc@example.com"},
-			expected: "abc@example.com",
+			name:         "User with email",
+			user:         &oauth.User{Email: "abc@example.com"},
+			expectedName: "abc@example.com",
 		},
 		{
-			name:     "User with username",
-			user:     &oauth.User{Username: "abc@example.com"},
-			expected: "abc@example.com",
+			name:         "User with username",
+			user:         &oauth.User{Username: "abc@example.com"},
+			expectedName: "abc@example.com",
 		},
 		{
-			name:     "User with username and email",
-			user:     &oauth.User{Username: "abc@example.com", Email: "def@example.com"},
-			expected: "abc@example.com",
+			name:         "User with username and email",
+			user:         &oauth.User{Username: "abc@example.com", Email: "def@example.com"},
+			expectedName: "abc@example.com",
 		},
 		{
-			name:     "User with subject",
-			user:     &oauth.User{Subject: "abc@example.com"},
-			expected: "abc@example.com",
+			name:         "User with subject",
+			user:         &oauth.User{Subject: "abc@example.com"},
+			expectedName: "abc@example.com",
 		},
 		{
-			name:     "Empty User - returns empty (no attribution)",
-			user:     &oauth.User{},
-			expected: "",
+			name:         "Empty User - returns mcp-trino-user (default attribution)",
+			user:         &oauth.User{},
+			expectedName: defaultAttributionUser,
 		},
 		{
-			name:     "Nil User - returns empty (no attribution)",
-			user:     nil,
-			expected: "",
+			name:         "Nil User - returns mcp-trino-user (default attribution)",
+			user:         nil,
+			expectedName: defaultAttributionUser,
 		},
 	}
 	for index := range tests {
@@ -638,9 +638,15 @@ func TestGetQueryUsername(t *testing.T) {
 			if tt.user != nil {
 				ctx = oauth.WithUser(ctx, tt.user)
 			}
-			result := getQueryUsername(ctx)
-			if result != tt.expected {
-				t.Errorf("getQueryUsername(%v) = %s, want %s", tt.user, result, tt.expected)
+			returnedUser, username := getOAuthUserAndUsername(ctx)
+			if username != tt.expectedName {
+				t.Errorf("getOAuthUserAndUsername(%v) username = %s, want %s", tt.user, username, tt.expectedName)
+			}
+			if tt.user == nil && returnedUser != nil {
+				t.Errorf("getOAuthUserAndUsername(%v) user = %v, want nil", tt.user, returnedUser)
+			}
+			if tt.user != nil && returnedUser == nil {
+				t.Errorf("getOAuthUserAndUsername(%v) user = nil, want non-nil", tt.user)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

Extract PE-7844 feature from Vungle/mcp-trino: per-query user identity attribution via Trino driver NamedArgs.

## Changes

- Always send `X-Trino-Client-Tags`, `X-Trino-Client-Info`, `X-Trino-Source` as NamedArgs for query attribution (defaults to `mcp-trino-user`)
- Send `X-Trino-User` NamedArg when impersonation is enabled, using `GetImpersonatedUser(ctx)` to respect `ImpersonationField` config
- Replace `getQueryUsername` with `getOAuthUserAndUsername` for single context lookup
- Update tests to cover new default attribution behavior

## What was NOT changed (no regressions)

- CLI mode, impersonation, row limiting, pre-compiled regexes, MCP tool annotations, WithContext method variants, sanitization-before-newlines fix

## Notes

- Dockerfile: no changes needed (same Alpine 3.22.2)
- oauth-mcp-proxy: no changes (Vungle uses their fork with different module path; upstream `tuannvm/oauth-mcp-proxy` already has newer versions)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added per-query user impersonation support when enabled.

* **Improvements**
  * Switched to OAuth-based user attribution with robust fallback for display names.
  * Consistently includes attribution and source information with each query.

* **Tests**
  * Updated tests to validate OAuth user and resolved display name behavior.

* **Chores**
  * Bumped Go toolchain and build images to 1.25.9.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->