### PR TITLE
refactor(cli): stdlib-only CLI with LLM-friendly help and JSON config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ vendor/
 .claude-plugin/mcp-trino.exe
 .claude-plugin/.mcp-trino-version
 .claude/
+.claude/harness/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,10 +61,12 @@ go test ./cmd                # Test mode detection and integration
    - Version management and build metadata
 
 2. **CLI Layer** (`internal/cli/`):
-   - `commands.go` - CLI subcommands (query, catalogs, schemas, tables, describe, explain)
-   - `repl.go` - Interactive REPL with meta-commands (\help, \quit, \history, etc.)
-   - `config.go` - CLI config file loading (~/.config/trino/config.yaml)
-   - Output formatting (table, json, csv) with deterministic column ordering
+   - `commands.go` - CLI subcommands with `io.Writer` injection for testability
+   - `repl.go` - Interactive REPL with injectable stdin/stdout for testing
+   - `config.go` - Dual-format config (YAML via `gopkg.in/yaml.v3` + JSON via `encoding/json`)
+   - Output formatting via `text/tabwriter` (table), `encoding/csv` (CSV), `encoding/json` (JSON)
+   - Structured LLM-friendly `--help` with NAME/SYNOPSIS/DESCRIPTION/COMMANDS/FLAGS/EXAMPLES/ENVIRONMENT
+   - Unix exit codes (0=success, 1=error, 2=usage) and signal handling (SIGINT/SIGTERM)
 
 3. **Configuration Layer** (`internal/config/config.go`):
    - Environment-based configuration with validation

--- a/README.md
+++ b/README.md
@@ -158,13 +158,37 @@ mcp-trino --format csv query "SELECT 1"
 mcp-trino --format table query "SELECT 1"  # default
 ```
 
+### Built-in Help
+
+Every command has structured, LLM-friendly help output:
+
+```bash
+# Main help with all commands, flags, examples, and environment variables
+mcp-trino --help
+
+# Per-subcommand help
+mcp-trino query --help
+mcp-trino describe --help
+```
+
+Help output follows Unix man-page conventions with sections: NAME, SYNOPSIS, DESCRIPTION, COMMANDS, FLAGS, EXAMPLES, ENVIRONMENT, and CONFIGURATION.
+
+### Exit Codes
+
+| Code | Meaning |
+|------|---------|
+| 0 | Success |
+| 1 | Runtime error (connection failed, query error, etc.) |
+| 2 | Usage error (unknown command, invalid flags, missing arguments) |
+
 ### Named Profiles
 
-mcp-trino supports named connection profiles for easy switching between Trino environments:
+mcp-trino supports named connection profiles for easy switching between Trino environments.
 
-**Configuration File** (~/.config/trino/config.yaml):
+**Configuration File** — supports both YAML (`~/.config/trino/config.yaml`) and JSON (`~/.config/trino/config.json`):
 
 ```yaml
+# ~/.config/trino/config.yaml
 current: prod
 
 profiles:
@@ -194,6 +218,31 @@ profiles:
 output:
   format: table
 ```
+
+Or equivalently in JSON:
+
+```json
+{
+  "current": "prod",
+  "profiles": {
+    "prod": {
+      "host": "trino.example.com",
+      "port": 443,
+      "user": "prod_user",
+      "catalog": "hive",
+      "ssl": { "enabled": true }
+    },
+    "dev": {
+      "host": "localhost",
+      "port": 8080,
+      "user": "trino"
+    }
+  },
+  "output": { "format": "table" }
+}
+```
+
+When both files exist, `config.json` takes precedence. New configs default to JSON.
 
 **Profile Management Commands:**
 

--- a/cmd/cli.go
+++ b/cmd/cli.go
@@ -84,7 +84,7 @@ func runCLI(stdout, stderr io.Writer, rawArgs []string) error {
 	}
 
 	if *showVersion {
-		fmt.Fprintf(stdout, "mcp-trino %s\n", Version)
+		_, _ = fmt.Fprintf(stdout, "mcp-trino %s\n", Version)
 		return nil
 	}
 
@@ -131,7 +131,7 @@ func runCLI(stdout, stderr io.Writer, rawArgs []string) error {
 		var loadErr error
 		cliConfig, loadErr = cli.LoadCLIConfig()
 		if loadErr != nil {
-			fmt.Fprintf(stderr, "Warning: failed to load CLI config: %v\n", loadErr)
+			_, _ = fmt.Fprintf(stderr, "Warning: failed to load CLI config: %v\n", loadErr)
 			cliConfig = cli.DefaultCLIConfig()
 		}
 	}
@@ -161,7 +161,7 @@ func runCLI(stdout, stderr io.Writer, rawArgs []string) error {
 
 	// Apply profile to environment
 	if err := cliConfig.ApplyToEnv(activeProfile); err != nil {
-		fmt.Fprintf(stderr, "Warning: failed to apply CLI config: %v\n", err)
+		_, _ = fmt.Fprintf(stderr, "Warning: failed to apply CLI config: %v\n", err)
 	}
 
 	// Apply CLI flags to environment (highest precedence)
@@ -207,7 +207,7 @@ func runCLI(stdout, stderr io.Writer, rawArgs []string) error {
 	}
 	defer func() {
 		if closeErr := trinoClient.Close(); closeErr != nil {
-			fmt.Fprintf(stderr, "Error closing Trino client: %v\n", closeErr)
+			_, _ = fmt.Fprintf(stderr, "Error closing Trino client: %v\n", closeErr)
 		}
 	}()
 
@@ -336,7 +336,7 @@ func isHelpRequest(args []string) bool {
 
 // printMainHelp prints structured, LLM-friendly help to w
 func printMainHelp(w io.Writer) {
-	fmt.Fprintf(w, `NAME
+	_, _ = fmt.Fprintf(w, `NAME
     mcp-trino - Trino SQL client and MCP server
 
 SYNOPSIS
@@ -433,7 +433,7 @@ SEE ALSO
 func printSubcommandHelp(w io.Writer, command string) {
 	switch command {
 	case "query":
-		fmt.Fprintf(w, `NAME
+		_, _ = fmt.Fprintf(w, `NAME
     mcp-trino query - Execute a SQL query
 
 SYNOPSIS
@@ -453,7 +453,7 @@ EXAMPLES
     mcp-trino --format csv query 'SELECT * FROM t' > out.csv
 `)
 	case "catalogs":
-		fmt.Fprintf(w, `NAME
+		_, _ = fmt.Fprintf(w, `NAME
     mcp-trino catalogs - List all available catalogs
 
 SYNOPSIS
@@ -467,7 +467,7 @@ EXAMPLES
     mcp-trino --format json catalogs
 `)
 	case "schemas":
-		fmt.Fprintf(w, `NAME
+		_, _ = fmt.Fprintf(w, `NAME
     mcp-trino schemas - List schemas in a catalog
 
 SYNOPSIS
@@ -484,7 +484,7 @@ EXAMPLES
     mcp-trino --format json schemas
 `)
 	case "tables":
-		fmt.Fprintf(w, `NAME
+		_, _ = fmt.Fprintf(w, `NAME
     mcp-trino tables - List tables in a schema
 
 SYNOPSIS
@@ -502,7 +502,7 @@ EXAMPLES
     mcp-trino --format json tables
 `)
 	case "describe":
-		fmt.Fprintf(w, `NAME
+		_, _ = fmt.Fprintf(w, `NAME
     mcp-trino describe - Describe table columns
 
 SYNOPSIS
@@ -522,7 +522,7 @@ EXAMPLES
     mcp-trino --format json describe my_table
 `)
 	case "explain":
-		fmt.Fprintf(w, `NAME
+		_, _ = fmt.Fprintf(w, `NAME
     mcp-trino explain - Show query execution plan
 
 SYNOPSIS
@@ -537,7 +537,7 @@ EXAMPLES
     mcp-trino --format json explain 'SELECT count(*) FROM t'
 `)
 	case "config":
-		fmt.Fprintf(w, `NAME
+		_, _ = fmt.Fprintf(w, `NAME
     mcp-trino config - Manage CLI configuration
 
 SYNOPSIS
@@ -559,7 +559,7 @@ EXAMPLES
     mcp-trino config profile show staging
 `)
 	case "interactive":
-		fmt.Fprintf(w, `NAME
+		_, _ = fmt.Fprintf(w, `NAME
     mcp-trino interactive - Start interactive REPL mode
 
 SYNOPSIS
@@ -579,8 +579,8 @@ EXAMPLES
     mcp-trino --profile staging interactive
 `)
 	default:
-		fmt.Fprintf(w, "No help available for command: %s\n", command)
-		fmt.Fprintf(w, "Run 'mcp-trino --help' for a list of commands.\n")
+		_, _ = fmt.Fprintf(w, "No help available for command: %s\n", command)
+		_, _ = fmt.Fprintf(w, "Run 'mcp-trino --help' for a list of commands.\n")
 	}
 }
 
@@ -601,14 +601,14 @@ func runConfigCommand(w io.Writer, args []string, cliConfig *cli.CLIConfig) erro
 // runConfigProfileCommand handles profile management commands
 func runConfigProfileCommand(w io.Writer, args []string, cliConfig *cli.CLIConfig) error {
 	if len(args) < 3 {
-		fmt.Fprintln(w, "config profile - Manage Trino connection profiles")
-		fmt.Fprintln(w)
-		fmt.Fprintln(w, "Usage:")
-		fmt.Fprintln(w, "  mcp-trino config profile list           List all profiles")
-		fmt.Fprintln(w, "  mcp-trino config profile use <name>      Set current profile")
-		fmt.Fprintln(w, "  mcp-trino config profile show <name>     Show profile details")
-		fmt.Fprintln(w)
-		fmt.Fprintf(w, "Current profile: %s\n", cliConfig.Current)
+		_, _ = fmt.Fprintln(w, "config profile - Manage Trino connection profiles")
+		_, _ = fmt.Fprintln(w)
+		_, _ = fmt.Fprintln(w, "Usage:")
+		_, _ = fmt.Fprintln(w, "  mcp-trino config profile list           List all profiles")
+		_, _ = fmt.Fprintln(w, "  mcp-trino config profile use <name>      Set current profile")
+		_, _ = fmt.Fprintln(w, "  mcp-trino config profile show <name>     Show profile details")
+		_, _ = fmt.Fprintln(w)
+		_, _ = fmt.Fprintf(w, "Current profile: %s\n", cliConfig.Current)
 		return nil
 	}
 
@@ -631,8 +631,8 @@ func runConfigProfileCommand(w io.Writer, args []string, cliConfig *cli.CLIConfi
 }
 
 func runProfileList(w io.Writer, cliConfig *cli.CLIConfig) error {
-	fmt.Fprintf(w, "Available profiles (current: %s):\n", cliConfig.Current)
-	fmt.Fprintln(w)
+	_, _ = fmt.Fprintf(w, "Available profiles (current: %s):\n", cliConfig.Current)
+	_, _ = fmt.Fprintln(w)
 
 	for _, name := range cliConfig.GetProfileNames() {
 		profile := cliConfig.Profiles[name]
@@ -640,10 +640,10 @@ func runProfileList(w io.Writer, cliConfig *cli.CLIConfig) error {
 		if name == cliConfig.Current {
 			currentMarker = " *"
 		}
-		fmt.Fprintf(w, "  %s%s: %s@%s:%d\n", name, currentMarker, profile.User, profile.Host, profile.Port)
+		_, _ = fmt.Fprintf(w, "  %s%s: %s@%s:%d\n", name, currentMarker, profile.User, profile.Host, profile.Port)
 	}
 
-	fmt.Fprintf(w, "\nTotal: %d profile(s)\n", len(cliConfig.Profiles))
+	_, _ = fmt.Fprintf(w, "\nTotal: %d profile(s)\n", len(cliConfig.Profiles))
 	return nil
 }
 
@@ -651,7 +651,7 @@ func runProfileUse(w io.Writer, cliConfig *cli.CLIConfig, name string) error {
 	if err := cliConfig.SetCurrent(name); err != nil {
 		return err
 	}
-	fmt.Fprintf(w, "Current profile set to: %s\n", name)
+	_, _ = fmt.Fprintf(w, "Current profile set to: %s\n", name)
 	return nil
 }
 
@@ -667,24 +667,24 @@ func runProfileShow(w io.Writer, cliConfig *cli.CLIConfig, name string) error {
 		currentMarker = " (current)"
 	}
 
-	fmt.Fprintf(w, "Profile: %s%s\n", name, currentMarker)
-	fmt.Fprintf(w, "  Host: %s\n", profile.Host)
-	fmt.Fprintf(w, "  Port: %d\n", profile.Port)
-	fmt.Fprintf(w, "  User: %s\n", profile.User)
+	_, _ = fmt.Fprintf(w, "Profile: %s%s\n", name, currentMarker)
+	_, _ = fmt.Fprintf(w, "  Host: %s\n", profile.Host)
+	_, _ = fmt.Fprintf(w, "  Port: %d\n", profile.Port)
+	_, _ = fmt.Fprintf(w, "  User: %s\n", profile.User)
 	if profile.Password != "" {
-		fmt.Fprintln(w, "  Password: ********")
+		_, _ = fmt.Fprintln(w, "  Password: ********")
 	}
 	if profile.Catalog != "" {
-		fmt.Fprintf(w, "  Catalog: %s\n", profile.Catalog)
+		_, _ = fmt.Fprintf(w, "  Catalog: %s\n", profile.Catalog)
 	}
 	if profile.Schema != "" {
-		fmt.Fprintf(w, "  Schema: %s\n", profile.Schema)
+		_, _ = fmt.Fprintf(w, "  Schema: %s\n", profile.Schema)
 	}
 	if profile.SSL.Enabled != nil {
-		fmt.Fprintf(w, "  SSL: %v\n", *profile.SSL.Enabled)
+		_, _ = fmt.Fprintf(w, "  SSL: %v\n", *profile.SSL.Enabled)
 	}
 	if profile.SSL.Insecure {
-		fmt.Fprintln(w, "  SSL Insecure: true")
+		_, _ = fmt.Fprintln(w, "  SSL Insecure: true")
 	}
 	return nil
 }

--- a/cmd/cli.go
+++ b/cmd/cli.go
@@ -4,13 +4,22 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"log"
+	"io"
 	"os"
+	"os/signal"
 	"strings"
+	"syscall"
 
 	"github.com/tuannvm/mcp-trino/internal/cli"
 	"github.com/tuannvm/mcp-trino/internal/config"
 	"github.com/tuannvm/mcp-trino/internal/trino"
+)
+
+// Exit codes following Unix conventions
+const (
+	exitOK    = 0
+	exitError = 1
+	exitUsage = 2
 )
 
 // cleanArgs removes mode selection flags from the argument list (before subcommand)
@@ -18,12 +27,9 @@ func cleanArgs(args []string) []string {
 	cleaned := make([]string, 0, len(args))
 	sawSubcommand := false
 	for _, arg := range args {
-		// Stop processing once we see a non-flag argument (subcommand)
 		if !strings.HasPrefix(arg, "-") && arg != "" {
 			sawSubcommand = true
 		}
-
-		// Only strip --cli/--mcp before the subcommand
 		if !sawSubcommand && (arg == "--cli" || arg == "--mcp") {
 			continue
 		}
@@ -42,88 +48,70 @@ func hasFlags(args []string) bool {
 	return false
 }
 
-// RunCLIMode executes the CLI mode
+// RunCLIMode executes the CLI mode and returns an exit code
 func RunCLIMode() error {
-	// Strip mode selection flags (--cli, --mcp) from args before parsing
-	args := cleanArgs(os.Args[1:])
+	return runCLI(os.Stdout, os.Stderr, os.Args[1:])
+}
 
-	// Define CLI flags
-	flagSet := flag.NewFlagSet("mcp-trino", flag.ExitOnError)
-	configFile := flagSet.String("config", "", "Path to config file")
-	profileName := flagSet.String("profile", "", "Profile name to use")
-	format := flagSet.String("format", "", "Output format (table, json, csv)")
+func runCLI(stdout, stderr io.Writer, rawArgs []string) error {
+	args := cleanArgs(rawArgs)
+
+	flagSet := flag.NewFlagSet("mcp-trino", flag.ContinueOnError)
+	flagSet.SetOutput(stderr)
+
+	configFile := flagSet.String("config", "", "Path to config file (default: ~/.config/trino/config.json)")
+	profileName := flagSet.String("profile", "", "Connection profile name")
+	format := flagSet.String("format", "", "Output format: table, json, csv (default: table)")
 	host := flagSet.String("host", "", "Trino host")
-	port := flagSet.Int("port", 0, "Trino port")
+	port := flagSet.Int("port", 0, "Trino port (default: 8080)")
 	user := flagSet.String("user", "", "Trino user")
 	password := flagSet.String("password", "", "Trino password")
 	catalog := flagSet.String("catalog", "", "Default catalog")
 	schema := flagSet.String("schema", "", "Default schema")
-	interactive := flagSet.Bool("interactive", false, "Interactive REPL mode")
+	interactive := flagSet.Bool("interactive", false, "Start interactive REPL mode")
 	showVersion := flagSet.Bool("version", false, "Show version information")
 
-	if err := flagSet.Parse(args); err != nil {
-		return err
+	// Override default usage to provide structured help
+	flagSet.Usage = func() {
+		printMainHelp(stderr)
 	}
 
-	// Handle version flag
+	if err := flagSet.Parse(args); err != nil {
+		if err == flag.ErrHelp {
+			return nil
+		}
+		return &usageError{err: err}
+	}
+
 	if *showVersion {
-		fmt.Printf("mcp-trino CLI version %s\n", Version)
+		fmt.Fprintf(stdout, "mcp-trino %s\n", Version)
 		return nil
 	}
 
-	// Get the subcommand
 	args = flagSet.Args()
 
-	// Validate subcommand before connecting to Trino
+	// Validate subcommand first, then check for --help
+	validCommands := map[string]bool{
+		"query": true, "catalogs": true, "schemas": true,
+		"tables": true, "describe": true, "explain": true,
+		"interactive": true, "config": true,
+	}
 	if len(args) > 0 && !*interactive {
-		validCommands := map[string]bool{
-			"query":       true,
-			"catalogs":    true,
-			"schemas":     true,
-			"tables":      true,
-			"describe":    true,
-			"explain":     true,
-			"interactive": true,
-			"config":      true, // config profile management
-		}
 		if !validCommands[args[0]] {
-			return fmt.Errorf("unknown command: %s (run 'mcp-trino' for usage)", args[0])
+			return &usageError{err: fmt.Errorf("unknown command: %s", args[0])}
+		}
+		if isHelpRequest(args) {
+			printSubcommandHelp(stderr, args[0])
+			return nil
 		}
 	}
 
 	if len(args) == 0 && !*interactive {
-		fmt.Println("mcp-trino CLI - Trino query tool")
-		fmt.Println()
-		fmt.Println("Usage:")
-		fmt.Println("  mcp-trino [flags] <command> [arguments]")
-		fmt.Println()
-		fmt.Println("Commands:")
-		fmt.Println("  query <sql>       Execute a SQL query")
-		fmt.Println("  catalogs          List all catalogs")
-		fmt.Println("  schemas <catalog> List schemas in a catalog")
-		fmt.Println("  tables <cat> <sch> List tables in schema")
-		fmt.Println("  describe <table>  Describe table schema")
-		fmt.Println("  explain <sql>     Explain query plan")
-		fmt.Println("  interactive       Start interactive REPL mode")
-		fmt.Println("  config profile    Manage connection profiles")
-		fmt.Println()
-		fmt.Println("Flags:")
-		flagSet.PrintDefaults()
-		fmt.Println()
-		fmt.Println("Environment Variables:")
-		fmt.Println("  TRINO_HOST, TRINO_PORT, TRINO_USER, TRINO_PASSWORD")
-		fmt.Println("  TRINO_CATALOG, TRINO_SCHEMA, TRINO_PROFILE")
-		fmt.Println()
-		fmt.Println("Examples:")
-		fmt.Println("  mcp-trino query 'SELECT 1'")
-		fmt.Println("  mcp-trino --profile staging catalogs")
-		fmt.Println("  mcp-trino config profile list")
-		fmt.Println("  mcp-trino config profile use prod")
-		fmt.Println("  mcp-trino --interactive")
+		printMainHelp(stderr)
 		return nil
 	}
 
-	// Load configuration from file if specified, otherwise load default
+	// Load configuration
 	var cliConfig *cli.CLIConfig
 	if *configFile != "" {
 		data, readErr := os.ReadFile(*configFile)
@@ -132,6 +120,10 @@ func RunCLIMode() error {
 		}
 		var parseErr error
 		cliConfig, parseErr = cli.ParseCLIConfigWithPath(data, *configFile)
+		if parseErr != nil && strings.HasSuffix(*configFile, ".yaml") {
+			// Retry as YAML for legacy config files
+			cliConfig, parseErr = cli.ParseYAMLConfigWithPath(data, *configFile)
+		}
 		if parseErr != nil {
 			return fmt.Errorf("failed to parse config file: %w", parseErr)
 		}
@@ -139,26 +131,23 @@ func RunCLIMode() error {
 		var loadErr error
 		cliConfig, loadErr = cli.LoadCLIConfig()
 		if loadErr != nil {
-			log.Printf("Warning: failed to load CLI config: %v", loadErr)
+			fmt.Fprintf(stderr, "Warning: failed to load CLI config: %v\n", loadErr)
 			cliConfig = cli.DefaultCLIConfig()
 		}
 	}
 
-	// Apply CLI config to environment (config file values, flags will override)
-	// Resolve profile name: --profile flag > TRINO_PROFILE env > current in config > default
+	// Resolve profile
 	activeProfile := *profileName
 	if activeProfile == "" {
 		activeProfile = os.Getenv("TRINO_PROFILE")
 	}
 
-	// Handle config command early (doesn't need Trino connection or profile validation)
+	// Handle config command early (doesn't need Trino connection)
 	if len(args) > 0 && args[0] == "config" {
-		// Config commands don't need profile validation - allow users to fix stale profiles
-		return runConfigCommand(args, cliConfig)
+		return runConfigCommand(stdout, args, cliConfig)
 	}
 
-	// Validate the profile that will be used (whether explicit or from current field)
-	// This prevents silent misconfiguration when current points to a missing profile
+	// Validate profile
 	profileToUse := activeProfile
 	if profileToUse == "" {
 		profileToUse = cliConfig.Current
@@ -166,85 +155,67 @@ func RunCLIMode() error {
 	if profileToUse == "" {
 		profileToUse = "default"
 	}
-	_, err := cliConfig.GetActiveProfile(profileToUse)
-	if err != nil {
-		// Fail hard if the resolved profile doesn't exist
+	if _, err := cliConfig.GetActiveProfile(profileToUse); err != nil {
 		return fmt.Errorf("profile '%s' not found: %w", profileToUse, err)
 	}
 
-	// Apply profile to environment (profiles override pre-existing env vars)
+	// Apply profile to environment
 	if err := cliConfig.ApplyToEnv(activeProfile); err != nil {
-		log.Printf("Warning: failed to apply CLI config: %v", err)
+		fmt.Fprintf(stderr, "Warning: failed to apply CLI config: %v\n", err)
 	}
 
-	// Apply CLI flags to environment (flags take precedence over everything)
-	if *host != "" {
-		_ = os.Setenv("TRINO_HOST", *host)
-	}
+	// Apply CLI flags to environment (highest precedence)
+	applyFlagToEnv("TRINO_HOST", *host)
 	if *port != 0 {
-		_ = os.Setenv("TRINO_PORT", fmt.Sprintf("%d", *port))
+		applyFlagToEnv("TRINO_PORT", fmt.Sprintf("%d", *port))
 	}
-	if *user != "" {
-		_ = os.Setenv("TRINO_USER", *user)
-	}
-	if *password != "" {
-		_ = os.Setenv("TRINO_PASSWORD", *password)
-	}
-	if *catalog != "" {
-		_ = os.Setenv("TRINO_CATALOG", *catalog)
-	}
-	if *schema != "" {
-		_ = os.Setenv("TRINO_SCHEMA", *schema)
-	}
+	applyFlagToEnv("TRINO_USER", *user)
+	applyFlagToEnv("TRINO_PASSWORD", *password)
+	applyFlagToEnv("TRINO_CATALOG", *catalog)
+	applyFlagToEnv("TRINO_SCHEMA", *schema)
 
-	// Validate required fields after precedence is applied (profile + CLI flags)
-	// This ensures fail-fast behavior for incomplete configuration
+	// Validate required fields
 	if os.Getenv("TRINO_HOST") == "" {
 		return fmt.Errorf("missing required configuration: host not set (provide via --host flag, profile, or TRINO_HOST env var)")
 	}
 	if os.Getenv("TRINO_USER") == "" {
 		return fmt.Errorf("missing required configuration: user not set (provide via --user flag, profile, or TRINO_USER env var)")
 	}
-	// Port is optional in config but TrinoConfig will use default 8080 if not set
-	// We allow this to pass since it's a reasonable default
 
-	// Determine output format
+	// Determine and validate output format
 	outputFormat := *format
 	if outputFormat == "" {
 		outputFormat = cliConfig.GetOutputFormat()
 	}
-
-	// Validate output format
 	validFormats := map[string]bool{"table": true, "json": true, "csv": true}
 	if outputFormat != "" && !validFormats[outputFormat] {
-		return fmt.Errorf("invalid output format '%s': must be one of table, json, csv", outputFormat)
+		return &usageError{err: fmt.Errorf("invalid output format '%s': must be one of table, json, csv", outputFormat)}
 	}
-
-	// Default to table if empty
 	if outputFormat == "" {
 		outputFormat = "table"
 	}
 
-	// Initialize Trino configuration
+	// Initialize Trino
 	trinoConfig, err := config.NewTrinoConfigWithVersion(Version)
 	if err != nil {
 		return fmt.Errorf("failed to load configuration: %w", err)
 	}
 
-	// Initialize Trino client
 	trinoClient, err := trino.NewClient(trinoConfig)
 	if err != nil {
 		return fmt.Errorf("failed to initialize Trino client: %w", err)
 	}
 	defer func() {
-		if err := trinoClient.Close(); err != nil {
-			log.Printf("Error closing Trino client: %v", err)
+		if closeErr := trinoClient.Close(); closeErr != nil {
+			fmt.Fprintf(stderr, "Error closing Trino client: %v\n", closeErr)
 		}
 	}()
 
-	// Create CLI commands handler
-	commands := cli.NewCommands(trinoClient, outputFormat)
-	ctx := context.Background()
+	commands := cli.NewCommandsWithWriters(trinoClient, outputFormat, stdout, stderr)
+
+	// Set up context with signal handling
+	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer cancel()
 
 	// Handle interactive mode
 	if *interactive || (len(args) > 0 && args[0] == "interactive") {
@@ -252,38 +223,33 @@ func RunCLIMode() error {
 		return repl.Run(ctx)
 	}
 
-	// Handle subcommands
+	// Dispatch subcommand
 	command := args[0]
 	commandArgs := args[1:]
 
 	switch command {
 	case "query":
 		if len(commandArgs) == 0 {
-			return fmt.Errorf("query command requires a SQL argument")
+			return &usageError{err: fmt.Errorf("query command requires a SQL argument")}
 		}
-		query := strings.Join(commandArgs, " ")
-		return commands.Query(ctx, query)
+		return commands.Query(ctx, strings.Join(commandArgs, " "))
 
 	case "catalogs":
 		return commands.Catalogs(ctx)
 
 	case "schemas":
-		// Create a subcommand flag set for schemas-specific flags
 		schemasFlagSet := flag.NewFlagSet("schemas", flag.ContinueOnError)
+		schemasFlagSet.SetOutput(stderr)
 		schemasCatalog := schemasFlagSet.String("catalog", "", "Catalog name")
-		// Parse the commandArgs as flags
 		if err := schemasFlagSet.Parse(commandArgs); err != nil {
-			// If flag parsing failed and no flags were present, treat as positional
 			if !hasFlags(commandArgs) && len(commandArgs) > 0 {
 				return commands.Schemas(ctx, commandArgs[0])
 			}
 			return fmt.Errorf("schemas command error: %w", err)
 		}
-		// Use flag value if set, otherwise use remaining positional arg
 		if *schemasCatalog != "" {
 			return commands.Schemas(ctx, *schemasCatalog)
 		}
-		// Use positional argument if provided
 		remainingArgs := schemasFlagSet.Args()
 		if len(remainingArgs) > 0 {
 			return commands.Schemas(ctx, remainingArgs[0])
@@ -291,13 +257,11 @@ func RunCLIMode() error {
 		return commands.Schemas(ctx, "")
 
 	case "tables":
-		// Create a subcommand flag set for tables-specific flags
 		tablesFlagSet := flag.NewFlagSet("tables", flag.ContinueOnError)
+		tablesFlagSet.SetOutput(stderr)
 		tablesCatalog := tablesFlagSet.String("catalog", "", "Catalog name")
 		tablesSchema := tablesFlagSet.String("schema", "", "Schema name")
-		// Parse the commandArgs as flags
 		if err := tablesFlagSet.Parse(commandArgs); err != nil {
-			// If flag parsing failed and no flags were present, treat as positional
 			if !hasFlags(commandArgs) {
 				if len(commandArgs) >= 2 {
 					return commands.Tables(ctx, commandArgs[0], commandArgs[1])
@@ -309,7 +273,6 @@ func RunCLIMode() error {
 			}
 			return fmt.Errorf("tables command error: %w", err)
 		}
-		// Use flag values if set, otherwise use remaining positional args
 		remainingArgs := tablesFlagSet.Args()
 		finalCatalog, finalSchema := "", ""
 		if *tablesCatalog != "" {
@@ -318,7 +281,6 @@ func RunCLIMode() error {
 		if *tablesSchema != "" {
 			finalSchema = *tablesSchema
 		}
-		// Positional args fill in missing values in order
 		posIndex := 0
 		if finalCatalog == "" && len(remainingArgs) > posIndex {
 			finalCatalog = remainingArgs[posIndex]
@@ -331,100 +293,369 @@ func RunCLIMode() error {
 
 	case "describe":
 		if len(commandArgs) == 0 {
-			return fmt.Errorf("describe command requires a table argument (format: catalog.schema.table)")
+			return &usageError{err: fmt.Errorf("describe command requires a table argument (format: catalog.schema.table)")}
 		}
-		table := commandArgs[0]
-		return commands.Describe(ctx, table)
+		return commands.Describe(ctx, commandArgs[0])
 
 	case "explain":
 		if len(commandArgs) == 0 {
-			return fmt.Errorf("explain command requires a SQL argument")
+			return &usageError{err: fmt.Errorf("explain command requires a SQL argument")}
 		}
-		query := strings.Join(commandArgs, " ")
-		return commands.Explain(ctx, query, "")
+		return commands.Explain(ctx, strings.Join(commandArgs, " "), "")
 
 	default:
-		return fmt.Errorf("unknown command: %s", command)
+		return &usageError{err: fmt.Errorf("unknown command: %s", command)}
+	}
+}
+
+// usageError represents a usage/argument error (exit code 2)
+type usageError struct {
+	err error
+}
+
+func (e *usageError) Error() string {
+	return e.err.Error()
+}
+
+// applyFlagToEnv sets an environment variable if value is non-empty
+func applyFlagToEnv(key, value string) {
+	if value != "" {
+		_ = os.Setenv(key, value)
+	}
+}
+
+// isHelpRequest checks if the args contain a help flag after a subcommand
+func isHelpRequest(args []string) bool {
+	for _, arg := range args[1:] {
+		if arg == "--help" || arg == "-h" {
+			return true
+		}
+	}
+	return false
+}
+
+// printMainHelp prints structured, LLM-friendly help to w
+func printMainHelp(w io.Writer) {
+	fmt.Fprintf(w, `NAME
+    mcp-trino - Trino SQL client and MCP server
+
+SYNOPSIS
+    mcp-trino [flags] <command> [arguments]
+    mcp-trino --interactive
+    mcp-trino --version
+
+DESCRIPTION
+    A dual-purpose tool that works as both an interactive Trino SQL client
+    and an MCP (Model Context Protocol) server for AI assistants.
+
+    When invoked with a subcommand or --interactive, it runs as a CLI.
+    Otherwise, it starts an MCP server (stdio or HTTP transport).
+
+COMMANDS
+    query <sql>              Execute a SQL query
+    catalogs                 List all available catalogs
+    schemas [catalog]        List schemas in a catalog
+    tables [catalog] [schema]  List tables in a schema
+    describe <table>         Describe table columns (catalog.schema.table)
+    explain <sql>            Show query execution plan
+    interactive              Start interactive REPL mode
+    config profile <action>  Manage connection profiles
+
+FLAGS
+    --config <path>     Path to config file (default: ~/.config/trino/config.json)
+    --profile <name>    Connection profile name
+    --format <fmt>      Output format: table, json, csv (default: table)
+    --host <host>       Trino host (overrides profile and env)
+    --port <port>       Trino port (default: 8080)
+    --user <user>       Trino user (overrides profile and env)
+    --password <pass>   Trino password
+    --catalog <name>    Default catalog
+    --schema <name>     Default schema
+    --interactive       Start interactive REPL mode
+    --version           Show version information
+    -h, --help          Show this help
+
+EXAMPLES
+    # Execute a query
+    mcp-trino query 'SELECT 1'
+
+    # List catalogs in JSON format
+    mcp-trino --format json catalogs
+
+    # Use a specific profile
+    mcp-trino --profile staging catalogs
+
+    # Start interactive REPL
+    mcp-trino --interactive
+
+    # Describe a table
+    mcp-trino describe memory.default.my_table
+
+    # Pipe-friendly: query with CSV output
+    mcp-trino --format csv query 'SELECT * FROM t' > results.csv
+
+    # Manage profiles
+    mcp-trino config profile list
+    mcp-trino config profile use prod
+
+ENVIRONMENT
+    TRINO_HOST              Trino server hostname
+    TRINO_PORT              Trino server port (default: 8080)
+    TRINO_USER              Trino username
+    TRINO_PASSWORD          Trino password
+    TRINO_CATALOG           Default catalog
+    TRINO_SCHEMA            Default schema
+    TRINO_PROFILE           Profile name (same as --profile flag)
+    TRINO_SSL               Enable SSL (true/false)
+    TRINO_SSL_INSECURE      Skip SSL certificate verification (true/false)
+    TRINO_ALLOW_WRITE_QUERIES  Allow write queries (default: false)
+    TRINO_QUERY_TIMEOUT     Query timeout in seconds (default: 30)
+    NO_COLOR                Disable colored output when set
+
+CONFIGURATION
+    Config file: ~/.config/trino/config.json
+
+    Precedence (highest to lowest):
+      1. CLI flags (--host, --user, etc.)
+      2. Profile from config file (--profile > TRINO_PROFILE > current)
+      3. Environment variables (TRINO_HOST, etc.)
+      4. Config file defaults
+
+    Note: Configuration uses JSON format. If migrating from an older YAML
+    config, convert ~/.config/trino/config.yaml to config.json manually.
+
+SEE ALSO
+    Use '<command> --help' for more information about a specific command.
+`)
+}
+
+// printSubcommandHelp prints help for a specific subcommand
+func printSubcommandHelp(w io.Writer, command string) {
+	switch command {
+	case "query":
+		fmt.Fprintf(w, `NAME
+    mcp-trino query - Execute a SQL query
+
+SYNOPSIS
+    mcp-trino [flags] query <sql>
+
+DESCRIPTION
+    Execute a SQL query against the configured Trino server and display
+    the results in the specified output format.
+
+    The query is passed as a single argument. Use quotes to prevent
+    shell interpretation of SQL operators.
+
+EXAMPLES
+    mcp-trino query 'SELECT 1'
+    mcp-trino query 'SELECT * FROM memory.default.my_table LIMIT 10'
+    mcp-trino --format json query 'SELECT count(*) FROM t'
+    mcp-trino --format csv query 'SELECT * FROM t' > out.csv
+`)
+	case "catalogs":
+		fmt.Fprintf(w, `NAME
+    mcp-trino catalogs - List all available catalogs
+
+SYNOPSIS
+    mcp-trino [flags] catalogs
+
+DESCRIPTION
+    List all catalogs available on the connected Trino server.
+
+EXAMPLES
+    mcp-trino catalogs
+    mcp-trino --format json catalogs
+`)
+	case "schemas":
+		fmt.Fprintf(w, `NAME
+    mcp-trino schemas - List schemas in a catalog
+
+SYNOPSIS
+    mcp-trino [flags] schemas [catalog]
+    mcp-trino [flags] schemas --catalog <name>
+
+DESCRIPTION
+    List all schemas within a catalog. If no catalog is specified,
+    uses TRINO_CATALOG env var or defaults to "memory".
+
+EXAMPLES
+    mcp-trino schemas memory
+    mcp-trino schemas --catalog hive
+    mcp-trino --format json schemas
+`)
+	case "tables":
+		fmt.Fprintf(w, `NAME
+    mcp-trino tables - List tables in a schema
+
+SYNOPSIS
+    mcp-trino [flags] tables [catalog] [schema]
+    mcp-trino [flags] tables --catalog <name> --schema <name>
+
+DESCRIPTION
+    List all tables within a schema. If catalog or schema are not
+    specified, uses TRINO_CATALOG/TRINO_SCHEMA env vars or defaults
+    to "memory"/"default".
+
+EXAMPLES
+    mcp-trino tables memory default
+    mcp-trino tables --catalog hive --schema public
+    mcp-trino --format json tables
+`)
+	case "describe":
+		fmt.Fprintf(w, `NAME
+    mcp-trino describe - Describe table columns
+
+SYNOPSIS
+    mcp-trino [flags] describe <table>
+
+DESCRIPTION
+    Show the column names, types, and metadata for a table.
+    The table argument can be in one of these formats:
+      - table
+      - schema.table
+      - catalog.schema.table
+
+EXAMPLES
+    mcp-trino describe my_table
+    mcp-trino describe public.my_table
+    mcp-trino describe memory.default.my_table
+    mcp-trino --format json describe my_table
+`)
+	case "explain":
+		fmt.Fprintf(w, `NAME
+    mcp-trino explain - Show query execution plan
+
+SYNOPSIS
+    mcp-trino [flags] explain <sql>
+
+DESCRIPTION
+    Display the execution plan for a SQL query without running it.
+    Useful for understanding query performance and optimization.
+
+EXAMPLES
+    mcp-trino explain 'SELECT * FROM t WHERE id = 1'
+    mcp-trino --format json explain 'SELECT count(*) FROM t'
+`)
+	case "config":
+		fmt.Fprintf(w, `NAME
+    mcp-trino config - Manage CLI configuration
+
+SYNOPSIS
+    mcp-trino config profile list
+    mcp-trino config profile use <name>
+    mcp-trino config profile show <name>
+
+DESCRIPTION
+    Manage connection profiles stored in the config file.
+
+SUBCOMMANDS
+    profile list          List all available profiles
+    profile use <name>    Set the current (default) profile
+    profile show <name>   Show details of a specific profile
+
+EXAMPLES
+    mcp-trino config profile list
+    mcp-trino config profile use prod
+    mcp-trino config profile show staging
+`)
+	case "interactive":
+		fmt.Fprintf(w, `NAME
+    mcp-trino interactive - Start interactive REPL mode
+
+SYNOPSIS
+    mcp-trino [flags] interactive
+    mcp-trino --interactive
+
+DESCRIPTION
+    Start an interactive SQL REPL (Read-Eval-Print Loop) with support
+    for multi-line queries, meta-commands, and command history.
+
+    Meta-commands start with \ (e.g., \help, \catalogs, \quit).
+    SQL queries are terminated with a semicolon (;).
+
+EXAMPLES
+    mcp-trino interactive
+    mcp-trino --interactive
+    mcp-trino --profile staging interactive
+`)
+	default:
+		fmt.Fprintf(w, "No help available for command: %s\n", command)
+		fmt.Fprintf(w, "Run 'mcp-trino --help' for a list of commands.\n")
 	}
 }
 
 // runConfigCommand handles config profile management commands
-func runConfigCommand(args []string, cliConfig *cli.CLIConfig) error {
+func runConfigCommand(w io.Writer, args []string, cliConfig *cli.CLIConfig) error {
 	if len(args) < 2 {
-		return fmt.Errorf("config command requires a subcommand: profile")
+		return &usageError{err: fmt.Errorf("config command requires a subcommand: profile")}
 	}
 
 	switch args[1] {
 	case "profile":
-		return runConfigProfileCommand(args, cliConfig)
+		return runConfigProfileCommand(w, args, cliConfig)
 	default:
-		return fmt.Errorf("unknown config subcommand: %s (available: profile)", args[1])
+		return &usageError{err: fmt.Errorf("unknown config subcommand: %s (available: profile)", args[1])}
 	}
 }
 
 // runConfigProfileCommand handles profile management commands
-func runConfigProfileCommand(args []string, cliConfig *cli.CLIConfig) error {
+func runConfigProfileCommand(w io.Writer, args []string, cliConfig *cli.CLIConfig) error {
 	if len(args) < 3 {
-		fmt.Println("config profile - Manage Trino connection profiles")
-		fmt.Println()
-		fmt.Println("Usage:")
-		fmt.Println("  mcp-trino config profile list           List all profiles")
-		fmt.Println("  mcp-trino config profile use <name>      Set current profile")
-		fmt.Println("  mcp-trino config profile show <name>     Show profile details")
-		fmt.Println()
-		fmt.Printf("Current profile: %s\n", cliConfig.Current)
+		fmt.Fprintln(w, "config profile - Manage Trino connection profiles")
+		fmt.Fprintln(w)
+		fmt.Fprintln(w, "Usage:")
+		fmt.Fprintln(w, "  mcp-trino config profile list           List all profiles")
+		fmt.Fprintln(w, "  mcp-trino config profile use <name>      Set current profile")
+		fmt.Fprintln(w, "  mcp-trino config profile show <name>     Show profile details")
+		fmt.Fprintln(w)
+		fmt.Fprintf(w, "Current profile: %s\n", cliConfig.Current)
 		return nil
 	}
 
 	switch args[2] {
 	case "list":
-		return runProfileList(cliConfig)
+		return runProfileList(w, cliConfig)
 	case "use":
 		if len(args) < 4 {
-			return fmt.Errorf("config profile use requires a profile name")
+			return &usageError{err: fmt.Errorf("config profile use requires a profile name")}
 		}
-		return runProfileUse(cliConfig, args[3])
+		return runProfileUse(w, cliConfig, args[3])
 	case "show":
 		if len(args) < 4 {
-			return fmt.Errorf("config profile show requires a profile name")
+			return &usageError{err: fmt.Errorf("config profile show requires a profile name")}
 		}
-		return runProfileShow(cliConfig, args[3])
+		return runProfileShow(w, cliConfig, args[3])
 	default:
-		return fmt.Errorf("unknown profile subcommand: %s (available: list, use, show)", args[2])
+		return &usageError{err: fmt.Errorf("unknown profile subcommand: %s (available: list, use, show)", args[2])}
 	}
 }
 
-// runProfileList lists all available profiles
-func runProfileList(cliConfig *cli.CLIConfig) error {
-	fmt.Printf("Available profiles (current: %s):\n", cliConfig.Current)
-	fmt.Println()
+func runProfileList(w io.Writer, cliConfig *cli.CLIConfig) error {
+	fmt.Fprintf(w, "Available profiles (current: %s):\n", cliConfig.Current)
+	fmt.Fprintln(w)
 
-	// Use sorted profile names for deterministic output
 	for _, name := range cliConfig.GetProfileNames() {
 		profile := cliConfig.Profiles[name]
 		currentMarker := ""
 		if name == cliConfig.Current {
 			currentMarker = " *"
 		}
-		fmt.Printf("  %s%s: %s@%s:%d\n", name, currentMarker, profile.User, profile.Host, profile.Port)
+		fmt.Fprintf(w, "  %s%s: %s@%s:%d\n", name, currentMarker, profile.User, profile.Host, profile.Port)
 	}
 
-	// List profile count
-	fmt.Printf("\nTotal: %d profile(s)\n", len(cliConfig.Profiles))
+	fmt.Fprintf(w, "\nTotal: %d profile(s)\n", len(cliConfig.Profiles))
 	return nil
 }
 
-// runProfileUse sets the current profile
-func runProfileUse(cliConfig *cli.CLIConfig, name string) error {
+func runProfileUse(w io.Writer, cliConfig *cli.CLIConfig, name string) error {
 	if err := cliConfig.SetCurrent(name); err != nil {
 		return err
 	}
-	fmt.Printf("Current profile set to: %s\n", name)
+	fmt.Fprintf(w, "Current profile set to: %s\n", name)
 	return nil
 }
 
-// runProfileShow shows detailed information about a profile
-func runProfileShow(cliConfig *cli.CLIConfig, name string) error {
+func runProfileShow(w io.Writer, cliConfig *cli.CLIConfig, name string) error {
 	profile, exists := cliConfig.Profiles[name]
 	if !exists {
 		return fmt.Errorf("profile '%s' not found. Available profiles: %v",
@@ -436,24 +667,24 @@ func runProfileShow(cliConfig *cli.CLIConfig, name string) error {
 		currentMarker = " (current)"
 	}
 
-	fmt.Printf("Profile: %s%s\n", name, currentMarker)
-	fmt.Printf("  Host: %s\n", profile.Host)
-	fmt.Printf("  Port: %d\n", profile.Port)
-	fmt.Printf("  User: %s\n", profile.User)
+	fmt.Fprintf(w, "Profile: %s%s\n", name, currentMarker)
+	fmt.Fprintf(w, "  Host: %s\n", profile.Host)
+	fmt.Fprintf(w, "  Port: %d\n", profile.Port)
+	fmt.Fprintf(w, "  User: %s\n", profile.User)
 	if profile.Password != "" {
-		fmt.Printf("  Password: ********\n")
+		fmt.Fprintln(w, "  Password: ********")
 	}
 	if profile.Catalog != "" {
-		fmt.Printf("  Catalog: %s\n", profile.Catalog)
+		fmt.Fprintf(w, "  Catalog: %s\n", profile.Catalog)
 	}
 	if profile.Schema != "" {
-		fmt.Printf("  Schema: %s\n", profile.Schema)
+		fmt.Fprintf(w, "  Schema: %s\n", profile.Schema)
 	}
 	if profile.SSL.Enabled != nil {
-		fmt.Printf("  SSL: %v\n", *profile.SSL.Enabled)
+		fmt.Fprintf(w, "  SSL: %v\n", *profile.SSL.Enabled)
 	}
 	if profile.SSL.Insecure {
-		fmt.Printf("  SSL Insecure: true\n")
+		fmt.Fprintln(w, "  SSL Insecure: true")
 	}
 	return nil
 }

--- a/cmd/cli.go
+++ b/cmd/cli.go
@@ -120,14 +120,6 @@ func runCLI(stdout, stderr io.Writer, rawArgs []string) error {
 		}
 		var parseErr error
 		cliConfig, parseErr = cli.ParseCLIConfigWithPath(data, *configFile)
-		if parseErr != nil && strings.HasSuffix(*configFile, ".yaml") {
-			// Legacy YAML config — parse and point ConfigPath at JSON for future saves
-			jsonPath := strings.TrimSuffix(*configFile, ".yaml") + ".json"
-			cliConfig, parseErr = cli.ParseYAMLConfigWithPath(data, jsonPath)
-			if parseErr == nil {
-				_ = cli.SaveCLIConfig(cliConfig)
-			}
-		}
 		if parseErr != nil {
 			return fmt.Errorf("failed to parse config file: %w", parseErr)
 		}

--- a/cmd/cli.go
+++ b/cmd/cli.go
@@ -121,8 +121,12 @@ func runCLI(stdout, stderr io.Writer, rawArgs []string) error {
 		var parseErr error
 		cliConfig, parseErr = cli.ParseCLIConfigWithPath(data, *configFile)
 		if parseErr != nil && strings.HasSuffix(*configFile, ".yaml") {
-			// Retry as YAML for legacy config files
-			cliConfig, parseErr = cli.ParseYAMLConfigWithPath(data, *configFile)
+			// Legacy YAML config — parse and point ConfigPath at JSON for future saves
+			jsonPath := strings.TrimSuffix(*configFile, ".yaml") + ".json"
+			cliConfig, parseErr = cli.ParseYAMLConfigWithPath(data, jsonPath)
+			if parseErr == nil {
+				_ = cli.SaveCLIConfig(cliConfig)
+			}
 		}
 		if parseErr != nil {
 			return fmt.Errorf("failed to parse config file: %w", parseErr)
@@ -245,7 +249,7 @@ func runCLI(stdout, stderr io.Writer, rawArgs []string) error {
 			if !hasFlags(commandArgs) && len(commandArgs) > 0 {
 				return commands.Schemas(ctx, commandArgs[0])
 			}
-			return fmt.Errorf("schemas command error: %w", err)
+			return &usageError{err: fmt.Errorf("schemas command error: %w", err)}
 		}
 		if *schemasCatalog != "" {
 			return commands.Schemas(ctx, *schemasCatalog)
@@ -271,7 +275,7 @@ func runCLI(stdout, stderr io.Writer, rawArgs []string) error {
 				}
 				return commands.Tables(ctx, "", "")
 			}
-			return fmt.Errorf("tables command error: %w", err)
+			return &usageError{err: fmt.Errorf("tables command error: %w", err)}
 		}
 		remainingArgs := tablesFlagSet.Args()
 		finalCatalog, finalSchema := "", ""
@@ -609,7 +613,7 @@ func runConfigProfileCommand(w io.Writer, args []string, cliConfig *cli.CLIConfi
 		_, _ = fmt.Fprintln(w, "  mcp-trino config profile show <name>     Show profile details")
 		_, _ = fmt.Fprintln(w)
 		_, _ = fmt.Fprintf(w, "Current profile: %s\n", cliConfig.Current)
-		return nil
+		return &usageError{err: fmt.Errorf("config profile requires a subcommand: list, use, or show")}
 	}
 
 	switch args[2] {

--- a/cmd/integration_test.go
+++ b/cmd/integration_test.go
@@ -68,8 +68,8 @@ func TestIntegration_HelpFlag(t *testing.T) {
 	}
 
 	outputStr := string(output)
-	if !strings.Contains(outputStr, "Usage of mcp-trino") {
-		t.Errorf("Expected help output to contain usage, got: %s", outputStr)
+	if !strings.Contains(outputStr, "mcp-trino") || !strings.Contains(outputStr, "SYNOPSIS") {
+		t.Errorf("Expected help output to contain structured help, got: %s", outputStr)
 	}
 }
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -65,11 +65,7 @@ func main() {
 
 	if explicitCLI || shouldRunCLIMode(args) {
 		if err := RunCLIMode(); err != nil {
-			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
-			if _, ok := err.(*usageError); ok {
-				os.Exit(exitUsage)
-			}
-			os.Exit(exitError)
+			exitCLIError(err)
 		}
 		return
 	}
@@ -84,13 +80,8 @@ func main() {
 		}
 
 		if isTTY() {
-			// Interactive terminal - show CLI help
 			if err := RunCLIMode(); err != nil {
-				fmt.Fprintf(os.Stderr, "Error: %v\n", err)
-				if _, ok := err.(*usageError); ok {
-					os.Exit(exitUsage)
-				}
-				os.Exit(exitError)
+				exitCLIError(err)
 			}
 			return
 		}
@@ -104,7 +95,7 @@ func main() {
 	// In this case, show CLI help (user likely wants CLI usage)
 	if hasCLIOnlyFlags(args) {
 		if err := RunCLIMode(); err != nil {
-			log.Fatalf("CLI error: %v", err)
+			exitCLIError(err)
 		}
 		return
 	}
@@ -249,6 +240,14 @@ func hasCLIOnlyFlags(args []string) bool {
 		}
 	}
 	return false
+}
+
+func exitCLIError(err error) {
+	_, _ = fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+	if _, ok := err.(*usageError); ok {
+		os.Exit(exitUsage)
+	}
+	os.Exit(exitError)
 }
 
 func getEnv(key, def string) string {

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"os"
 	"strings"
@@ -63,9 +64,12 @@ func main() {
 	}
 
 	if explicitCLI || shouldRunCLIMode(args) {
-		// CLI mode
 		if err := RunCLIMode(); err != nil {
-			log.Fatalf("CLI error: %v", err)
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+			if _, ok := err.(*usageError); ok {
+				os.Exit(exitUsage)
+			}
+			os.Exit(exitError)
 		}
 		return
 	}
@@ -82,7 +86,11 @@ func main() {
 		if isTTY() {
 			// Interactive terminal - show CLI help
 			if err := RunCLIMode(); err != nil {
-				log.Fatalf("CLI error: %v", err)
+				fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+				if _, ok := err.(*usageError); ok {
+					os.Exit(exitUsage)
+				}
+				os.Exit(exitError)
 			}
 			return
 		}

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -1,7 +1,9 @@
 package main
 
 import (
+	"bytes"
 	"os"
+	"strings"
 	"testing"
 )
 
@@ -299,5 +301,203 @@ func TestIsTTY(t *testing.T) {
 	result := isTTY()
 	if result != true && result != false {
 		t.Errorf("isTTY() returned non-boolean value")
+	}
+}
+
+// --- Structured help output tests ---
+
+func TestMainHelp_StructuredSections(t *testing.T) {
+	var buf bytes.Buffer
+	printMainHelp(&buf)
+	output := buf.String()
+
+	requiredSections := []string{
+		"NAME", "SYNOPSIS", "DESCRIPTION", "COMMANDS",
+		"FLAGS", "EXAMPLES", "ENVIRONMENT", "CONFIGURATION",
+	}
+	for _, section := range requiredSections {
+		if !strings.Contains(output, section) {
+			t.Errorf("main help missing required section: %s", section)
+		}
+	}
+
+	// Verify all subcommands are documented
+	commands := []string{"query", "catalogs", "schemas", "tables", "describe", "explain", "interactive", "config"}
+	for _, cmd := range commands {
+		if !strings.Contains(output, cmd) {
+			t.Errorf("main help missing command: %s", cmd)
+		}
+	}
+
+	// Verify all env vars are documented
+	envVars := []string{
+		"TRINO_HOST", "TRINO_PORT", "TRINO_USER", "TRINO_PASSWORD",
+		"TRINO_CATALOG", "TRINO_SCHEMA", "TRINO_PROFILE",
+		"TRINO_QUERY_TIMEOUT", "NO_COLOR",
+	}
+	for _, env := range envVars {
+		if !strings.Contains(output, env) {
+			t.Errorf("main help missing env var: %s", env)
+		}
+	}
+}
+
+func TestSubcommandHelp_AllCommands(t *testing.T) {
+	commands := []string{"query", "catalogs", "schemas", "tables", "describe", "explain", "config", "interactive"}
+
+	for _, cmd := range commands {
+		t.Run(cmd, func(t *testing.T) {
+			var buf bytes.Buffer
+			printSubcommandHelp(&buf, cmd)
+			output := buf.String()
+
+			// Every subcommand help must have NAME, SYNOPSIS, DESCRIPTION, EXAMPLES
+			for _, section := range []string{"NAME", "SYNOPSIS", "DESCRIPTION"} {
+				if !strings.Contains(output, section) {
+					t.Errorf("%s --help missing section: %s", cmd, section)
+				}
+			}
+
+			// Must mention the command name
+			if !strings.Contains(output, "mcp-trino "+cmd) {
+				t.Errorf("%s --help doesn't mention 'mcp-trino %s'", cmd, cmd)
+			}
+		})
+	}
+}
+
+func TestSubcommandHelp_Unknown(t *testing.T) {
+	var buf bytes.Buffer
+	printSubcommandHelp(&buf, "nonexistent")
+	output := buf.String()
+	if !strings.Contains(output, "No help available") {
+		t.Errorf("expected 'No help available' for unknown command, got: %s", output)
+	}
+}
+
+// --- Exit code / usageError tests ---
+
+func TestRunCLI_UsageError_UnknownCommand(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	err := runCLI(&stdout, &stderr, []string{"qury"})
+	if err == nil {
+		t.Fatal("expected error for unknown command")
+	}
+	if _, ok := err.(*usageError); !ok {
+		t.Errorf("expected *usageError, got %T: %v", err, err)
+	}
+	if !strings.Contains(err.Error(), "unknown command") {
+		t.Errorf("expected 'unknown command' in error, got: %v", err)
+	}
+}
+
+func TestRunCLI_UsageError_InvalidFormat(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	err := runCLI(&stdout, &stderr, []string{"--format", "xml", "catalogs"})
+	if err == nil {
+		t.Fatal("expected error for invalid format")
+	}
+	if _, ok := err.(*usageError); !ok {
+		t.Errorf("expected *usageError for invalid format, got %T: %v", err, err)
+	}
+}
+
+func TestRunCLI_UsageError_QueryNoArg(t *testing.T) {
+	// Set required env vars so we get past config validation
+	_ = os.Setenv("TRINO_HOST", "localhost")
+	_ = os.Setenv("TRINO_USER", "test")
+	t.Cleanup(func() {
+		_ = os.Unsetenv("TRINO_HOST")
+		_ = os.Unsetenv("TRINO_USER")
+	})
+
+	var stdout, stderr bytes.Buffer
+	err := runCLI(&stdout, &stderr, []string{"query"})
+	if err == nil {
+		t.Fatal("expected error for query with no SQL arg")
+	}
+	if _, ok := err.(*usageError); !ok {
+		t.Errorf("expected *usageError for query with no arg, got %T: %v", err, err)
+	}
+}
+
+func TestRunCLI_UsageError_DescribeNoArg(t *testing.T) {
+	_ = os.Setenv("TRINO_HOST", "localhost")
+	_ = os.Setenv("TRINO_USER", "test")
+	t.Cleanup(func() {
+		_ = os.Unsetenv("TRINO_HOST")
+		_ = os.Unsetenv("TRINO_USER")
+	})
+
+	var stdout, stderr bytes.Buffer
+	err := runCLI(&stdout, &stderr, []string{"describe"})
+	if err == nil {
+		t.Fatal("expected error for describe with no table arg")
+	}
+	if _, ok := err.(*usageError); !ok {
+		t.Errorf("expected *usageError for describe with no arg, got %T: %v", err, err)
+	}
+}
+
+func TestRunCLI_UsageError_ConfigProfileNoSubcommand(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	err := runCLI(&stdout, &stderr, []string{"config", "profile"})
+	if err == nil {
+		t.Fatal("expected error for config profile with no subcommand")
+	}
+	if _, ok := err.(*usageError); !ok {
+		t.Errorf("expected *usageError, got %T: %v", err, err)
+	}
+}
+
+func TestRunCLI_NoError_HelpFlag(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	err := runCLI(&stdout, &stderr, []string{"--help"})
+	if err != nil {
+		t.Errorf("--help should not return error, got: %v", err)
+	}
+	if !strings.Contains(stderr.String(), "NAME") {
+		t.Error("--help should print structured help to stderr")
+	}
+}
+
+func TestRunCLI_NoError_VersionFlag(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	err := runCLI(&stdout, &stderr, []string{"--version"})
+	if err != nil {
+		t.Errorf("--version should not return error, got: %v", err)
+	}
+	if !strings.Contains(stdout.String(), "mcp-trino") {
+		t.Error("--version should print version to stdout")
+	}
+}
+
+func TestRunCLI_NoError_SubcommandHelp(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	err := runCLI(&stdout, &stderr, []string{"query", "--help"})
+	if err != nil {
+		t.Errorf("query --help should not return error, got: %v", err)
+	}
+	if !strings.Contains(stderr.String(), "SYNOPSIS") {
+		t.Error("query --help should print structured help")
+	}
+}
+
+func TestRunCLI_MissingHost(t *testing.T) {
+	// Use a profile that doesn't set host to override defaults
+	tmpDir := t.TempDir()
+	configPath := tmpDir + "/config.json"
+	_ = os.WriteFile(configPath, []byte(`{"current":"empty","profiles":{"empty":{"port":8080,"user":"u"}}}`), 0600)
+
+	_ = os.Unsetenv("TRINO_HOST")
+	_ = os.Unsetenv("TRINO_USER")
+
+	var stdout, stderr bytes.Buffer
+	err := runCLI(&stdout, &stderr, []string{"--config", configPath, "catalogs"})
+	if err == nil {
+		t.Fatal("expected error when host is missing")
+	}
+	if !strings.Contains(err.Error(), "host not set") {
+		t.Errorf("expected 'host not set' error, got: %v", err)
 	}
 }

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -101,13 +101,17 @@ mcp-trino --version
 export TRINO_HOST=localhost TRINO_PORT=8080 TRINO_USER=trino
 mcp-trino catalogs
 
-# Or use config file
+# Or use config file (YAML or JSON)
 mkdir -p ~/.config/trino
 cat > ~/.config/trino/config.yaml << EOF
-trino:
-  host: localhost
-  port: 8080
-  user: trino
+current: default
+profiles:
+  default:
+    host: localhost
+    port: 8080
+    user: trino
+    catalog: memory
+    schema: default
 EOF
 
 mcp-trino catalogs

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/mark3labs/mcp-go v0.43.1
 	github.com/trinodb/trino-go-client v0.328.0
 	github.com/tuannvm/oauth-mcp-proxy v1.0.1
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
@@ -32,5 +33,4 @@ require (
 	golang.org/x/crypto v0.45.0 // indirect
 	golang.org/x/net v0.47.0 // indirect
 	golang.org/x/oauth2 v0.32.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,6 @@ require (
 	github.com/mark3labs/mcp-go v0.43.1
 	github.com/trinodb/trino-go-client v0.328.0
 	github.com/tuannvm/oauth-mcp-proxy v1.0.1
-	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
@@ -33,4 +32,5 @@ require (
 	golang.org/x/crypto v0.45.0 // indirect
 	golang.org/x/net v0.47.0 // indirect
 	golang.org/x/oauth2 v0.32.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/internal/cli/commands.go
+++ b/internal/cli/commands.go
@@ -2,11 +2,14 @@ package cli
 
 import (
 	"context"
+	"encoding/csv"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"sort"
 	"strings"
+	"text/tabwriter"
 
 	"github.com/tuannvm/mcp-trino/internal/trino"
 )
@@ -27,6 +30,8 @@ type TrinoClient interface {
 type Commands struct {
 	client TrinoClient
 	format string // output format: table, json, csv
+	out    io.Writer
+	errOut io.Writer
 }
 
 // NewCommands creates a new CLI commands handler
@@ -37,6 +42,21 @@ func NewCommands(client TrinoClient, format string) *Commands {
 	return &Commands{
 		client: client,
 		format: format,
+		out:    os.Stdout,
+		errOut: os.Stderr,
+	}
+}
+
+// NewCommandsWithWriters creates a new CLI commands handler with custom writers
+func NewCommandsWithWriters(client TrinoClient, format string, out, errOut io.Writer) *Commands {
+	if format == "" {
+		format = "table"
+	}
+	return &Commands{
+		client: client,
+		format: format,
+		out:    out,
+		errOut: errOut,
 	}
 }
 
@@ -51,7 +71,6 @@ func (c *Commands) Query(ctx context.Context, query string) error {
 		return fmt.Errorf("query failed: %w", err)
 	}
 
-	// Format and display results
 	return c.formatOutput(results)
 }
 
@@ -68,22 +87,19 @@ func (c *Commands) Catalogs(ctx context.Context) error {
 		})
 	}
 
-	// Simple table output
-	fmt.Println("Catalogs:")
+	fmt.Fprintln(c.out, "Catalogs:")
 	for _, catalog := range catalogs {
-		fmt.Printf("  - %s\n", catalog)
+		fmt.Fprintf(c.out, "  - %s\n", catalog)
 	}
 	return nil
 }
 
 // Schemas lists schemas in a catalog
 func (c *Commands) Schemas(ctx context.Context, catalog string) error {
-	// Use default catalog from config if not specified
 	if catalog == "" {
-		// Get catalog from environment or default
 		catalog = os.Getenv("TRINO_CATALOG")
 		if catalog == "" {
-			catalog = "memory" // default Trino catalog
+			catalog = "memory"
 		}
 	}
 
@@ -99,26 +115,25 @@ func (c *Commands) Schemas(ctx context.Context, catalog string) error {
 		})
 	}
 
-	fmt.Printf("Schemas in catalog '%s':\n", catalog)
+	fmt.Fprintf(c.out, "Schemas in catalog '%s':\n", catalog)
 	for _, schema := range schemas {
-		fmt.Printf("  - %s\n", schema)
+		fmt.Fprintf(c.out, "  - %s\n", schema)
 	}
 	return nil
 }
 
 // Tables lists tables in a schema
 func (c *Commands) Tables(ctx context.Context, catalog, schema string) error {
-	// Use defaults from config if not specified
 	if catalog == "" {
 		catalog = os.Getenv("TRINO_CATALOG")
 		if catalog == "" {
-			catalog = "memory" // default Trino catalog
+			catalog = "memory"
 		}
 	}
 	if schema == "" {
 		schema = os.Getenv("TRINO_SCHEMA")
 		if schema == "" {
-			schema = "default" // default Trino schema
+			schema = "default"
 		}
 	}
 
@@ -135,9 +150,9 @@ func (c *Commands) Tables(ctx context.Context, catalog, schema string) error {
 		})
 	}
 
-	fmt.Printf("Tables in %s.%s:\n", catalog, schema)
+	fmt.Fprintf(c.out, "Tables in %s.%s:\n", catalog, schema)
 	for _, table := range tables {
-		fmt.Printf("  - %s\n", table)
+		fmt.Fprintf(c.out, "  - %s\n", table)
 	}
 	return nil
 }
@@ -157,9 +172,8 @@ func (c *Commands) Describe(ctx context.Context, table string) error {
 		return c.outputJSON(schemaInfo)
 	}
 
-	// Use the requested table name for display
-	fmt.Printf("Table: %s\n", table)
-	fmt.Println("\nColumns:")
+	fmt.Fprintf(c.out, "Table: %s\n", table)
+	fmt.Fprintln(c.out, "\nColumns:")
 	for _, row := range schemaInfo.Rows {
 		colName := fmt.Sprintf("%v", row["Column"])
 		colType := fmt.Sprintf("%v", row["Type"])
@@ -173,9 +187,9 @@ func (c *Commands) Describe(ctx context.Context, table string) error {
 			}
 			extra += fmt.Sprintf("# %s", comment)
 		}
-		fmt.Printf("  - %-30s %-20s%s\n", colName, colType, extra)
+		fmt.Fprintf(c.out, "  - %-30s %-20s%s\n", colName, colType, extra)
 	}
-	fmt.Printf("\n%d column(s)\n", len(schemaInfo.Rows))
+	fmt.Fprintf(c.out, "\n%d column(s)\n", len(schemaInfo.Rows))
 	return nil
 }
 
@@ -197,19 +211,16 @@ func (c *Commands) Explain(ctx context.Context, query string, formatOpt string) 
 		})
 	}
 
-	// Print the query plan from the result rows
-	fmt.Printf("Query Plan for: %s\n\n", query)
+	fmt.Fprintf(c.out, "Query Plan for: %s\n\n", query)
 	for _, row := range result.Rows {
-		// EXPLAIN results typically have a single column with the plan
 		for _, val := range row {
-			fmt.Printf("%v\n", val)
+			fmt.Fprintf(c.out, "%v\n", val)
 		}
 	}
 	return nil
 }
 
-// Helper functions
-
+// formatOutput dispatches to the appropriate output formatter
 func (c *Commands) formatOutput(results interface{}) error {
 	switch c.format {
 	case "json":
@@ -217,122 +228,117 @@ func (c *Commands) formatOutput(results interface{}) error {
 	case "csv":
 		return c.outputCSV(results)
 	default:
-		// Default table formatting
 		return c.outputTable(results)
 	}
 }
 
 func (c *Commands) outputJSON(data interface{}) error {
-	encoder := json.NewEncoder(os.Stdout)
+	encoder := json.NewEncoder(c.out)
 	encoder.SetIndent("", "  ")
 	return encoder.Encode(data)
 }
 
 func (c *Commands) outputCSV(results interface{}) error {
-	// Type assertion for query results
 	queryResults, ok := results.(*trino.QueryResult)
 	if !ok {
 		return fmt.Errorf("invalid result type")
 	}
 
 	if len(queryResults.Rows) == 0 {
-		fmt.Println("No results")
+		fmt.Fprintln(c.out, "No results")
 		return nil
 	}
 
-	// Extract column names from the first row and sort for deterministic output
-	columns := make([]string, 0, len(queryResults.Rows[0]))
-	for col := range queryResults.Rows[0] {
-		columns = append(columns, col)
-	}
-	sort.Strings(columns)
+	columns := extractSortedColumns(queryResults.Rows[0])
 
-	// Write CSV header
-	for i, col := range columns {
-		if i > 0 {
-			fmt.Print(",")
-		}
-		fmt.Printf("%q", col)
+	w := csv.NewWriter(c.out)
+
+	// Write header
+	if err := w.Write(columns); err != nil {
+		return fmt.Errorf("failed to write CSV header: %w", err)
 	}
-	fmt.Println()
 
 	// Write data rows
+	record := make([]string, len(columns))
 	for _, row := range queryResults.Rows {
 		for i, col := range columns {
-			if i > 0 {
-				fmt.Print(",")
-			}
-			// Convert value to string and quote it
-			val := fmt.Sprintf("%v", row[col])
-			fmt.Printf("%q", val)
+			record[i] = fmt.Sprintf("%v", row[col])
 		}
-		fmt.Println()
+		if err := w.Write(record); err != nil {
+			return fmt.Errorf("failed to write CSV row: %w", err)
+		}
+	}
+
+	w.Flush()
+	if err := w.Error(); err != nil {
+		return fmt.Errorf("CSV write error: %w", err)
 	}
 
 	if queryResults.Truncated {
-		fmt.Printf("# %d row(s) (truncated, max %d)\n", len(queryResults.Rows), queryResults.MaxRows)
+		fmt.Fprintf(c.out, "# %d row(s) (truncated, max %d)\n", len(queryResults.Rows), queryResults.MaxRows)
 	}
 	return nil
 }
 
 func (c *Commands) outputTable(results interface{}) error {
-	// Type assertion for query results
 	queryResults, ok := results.(*trino.QueryResult)
 	if !ok {
 		return fmt.Errorf("invalid result type")
 	}
 
 	if len(queryResults.Rows) == 0 {
-		fmt.Println("No results")
+		fmt.Fprintln(c.out, "No results")
 		return nil
 	}
 
-	// Extract column names from the first row and sort for deterministic output
-	columns := make([]string, 0, len(queryResults.Rows[0]))
-	for col := range queryResults.Rows[0] {
-		columns = append(columns, col)
-	}
-	sort.Strings(columns)
+	columns := extractSortedColumns(queryResults.Rows[0])
 
-	// Calculate column widths
-	colWidths := make([]int, len(columns))
+	tw := tabwriter.NewWriter(c.out, 0, 0, 2, ' ', 0)
+
+	// Header
+	fmt.Fprintln(tw, strings.Join(columns, "\t"))
+
+	// Separator
+	seps := make([]string, len(columns))
 	for i, col := range columns {
-		colWidths[i] = len(col)
-	}
-	for _, row := range queryResults.Rows {
-		for i, col := range columns {
+		width := len(col)
+		for _, row := range queryResults.Rows {
 			strVal := fmt.Sprintf("%v", row[col])
-			if len(strVal) > colWidths[i] {
-				colWidths[i] = len(strVal)
+			if len(strVal) > width {
+				width = len(strVal)
 			}
 		}
+		seps[i] = strings.Repeat("-", width)
 	}
+	fmt.Fprintln(tw, strings.Join(seps, "\t"))
 
-	// Print header
-	for i, col := range columns {
-		fmt.Printf("%-*s", colWidths[i]+2, col)
-	}
-	fmt.Println()
-
-	// Print separator
-	for _, width := range colWidths {
-		fmt.Printf("%-*s", width+2, strings.Repeat("-", width))
-	}
-	fmt.Println()
-
-	// Print data rows
+	// Data rows
+	vals := make([]string, len(columns))
 	for _, row := range queryResults.Rows {
 		for i, col := range columns {
-			fmt.Printf("%-*v", colWidths[i]+2, row[col])
+			vals[i] = fmt.Sprintf("%v", row[col])
 		}
-		fmt.Println()
+		fmt.Fprintln(tw, strings.Join(vals, "\t"))
+	}
+
+	if err := tw.Flush(); err != nil {
+		return fmt.Errorf("table write error: %w", err)
 	}
 
 	if queryResults.Truncated {
-		fmt.Printf("\n%d row(s) (truncated, max %d)\n", len(queryResults.Rows), queryResults.MaxRows)
+		fmt.Fprintf(c.out, "\n%d row(s) (truncated, max %d)\n", len(queryResults.Rows), queryResults.MaxRows)
 	} else {
-		fmt.Printf("\n%d row(s)\n", len(queryResults.Rows))
+		fmt.Fprintf(c.out, "\n%d row(s)\n", len(queryResults.Rows))
 	}
 	return nil
 }
 
+// extractSortedColumns returns sorted column names from a result row
+func extractSortedColumns(row map[string]interface{}) []string {
+	columns := make([]string, 0, len(row))
+	for col := range row {
+		columns = append(columns, col)
+	}
+	sort.Strings(columns)
+	return columns
+}

--- a/internal/cli/commands.go
+++ b/internal/cli/commands.go
@@ -275,7 +275,7 @@ func (c *Commands) outputCSV(results interface{}) error {
 	}
 
 	if queryResults.Truncated {
-		_, _ = fmt.Fprintf(c.out, "# %d row(s) (truncated, max %d)\n", len(queryResults.Rows), queryResults.MaxRows)
+		_, _ = fmt.Fprintf(c.errOut, "# %d row(s) (truncated, max %d)\n", len(queryResults.Rows), queryResults.MaxRows)
 	}
 	return nil
 }

--- a/internal/cli/commands.go
+++ b/internal/cli/commands.go
@@ -87,9 +87,9 @@ func (c *Commands) Catalogs(ctx context.Context) error {
 		})
 	}
 
-	fmt.Fprintln(c.out, "Catalogs:")
+	_, _ = fmt.Fprintln(c.out, "Catalogs:")
 	for _, catalog := range catalogs {
-		fmt.Fprintf(c.out, "  - %s\n", catalog)
+		_, _ = fmt.Fprintf(c.out, "  - %s\n", catalog)
 	}
 	return nil
 }
@@ -115,9 +115,9 @@ func (c *Commands) Schemas(ctx context.Context, catalog string) error {
 		})
 	}
 
-	fmt.Fprintf(c.out, "Schemas in catalog '%s':\n", catalog)
+	_, _ = fmt.Fprintf(c.out, "Schemas in catalog '%s':\n", catalog)
 	for _, schema := range schemas {
-		fmt.Fprintf(c.out, "  - %s\n", schema)
+		_, _ = fmt.Fprintf(c.out, "  - %s\n", schema)
 	}
 	return nil
 }
@@ -150,9 +150,9 @@ func (c *Commands) Tables(ctx context.Context, catalog, schema string) error {
 		})
 	}
 
-	fmt.Fprintf(c.out, "Tables in %s.%s:\n", catalog, schema)
+	_, _ = fmt.Fprintf(c.out, "Tables in %s.%s:\n", catalog, schema)
 	for _, table := range tables {
-		fmt.Fprintf(c.out, "  - %s\n", table)
+		_, _ = fmt.Fprintf(c.out, "  - %s\n", table)
 	}
 	return nil
 }
@@ -172,8 +172,8 @@ func (c *Commands) Describe(ctx context.Context, table string) error {
 		return c.outputJSON(schemaInfo)
 	}
 
-	fmt.Fprintf(c.out, "Table: %s\n", table)
-	fmt.Fprintln(c.out, "\nColumns:")
+	_, _ = fmt.Fprintf(c.out, "Table: %s\n", table)
+	_, _ = fmt.Fprintln(c.out, "\nColumns:")
 	for _, row := range schemaInfo.Rows {
 		colName := fmt.Sprintf("%v", row["Column"])
 		colType := fmt.Sprintf("%v", row["Type"])
@@ -187,9 +187,9 @@ func (c *Commands) Describe(ctx context.Context, table string) error {
 			}
 			extra += fmt.Sprintf("# %s", comment)
 		}
-		fmt.Fprintf(c.out, "  - %-30s %-20s%s\n", colName, colType, extra)
+		_, _ = fmt.Fprintf(c.out, "  - %-30s %-20s%s\n", colName, colType, extra)
 	}
-	fmt.Fprintf(c.out, "\n%d column(s)\n", len(schemaInfo.Rows))
+	_, _ = fmt.Fprintf(c.out, "\n%d column(s)\n", len(schemaInfo.Rows))
 	return nil
 }
 
@@ -211,10 +211,10 @@ func (c *Commands) Explain(ctx context.Context, query string, formatOpt string) 
 		})
 	}
 
-	fmt.Fprintf(c.out, "Query Plan for: %s\n\n", query)
+	_, _ = fmt.Fprintf(c.out, "Query Plan for: %s\n\n", query)
 	for _, row := range result.Rows {
 		for _, val := range row {
-			fmt.Fprintf(c.out, "%v\n", val)
+			_, _ = fmt.Fprintf(c.out, "%v\n", val)
 		}
 	}
 	return nil
@@ -245,7 +245,7 @@ func (c *Commands) outputCSV(results interface{}) error {
 	}
 
 	if len(queryResults.Rows) == 0 {
-		fmt.Fprintln(c.out, "No results")
+		_, _ = fmt.Fprintln(c.out, "No results")
 		return nil
 	}
 
@@ -275,7 +275,7 @@ func (c *Commands) outputCSV(results interface{}) error {
 	}
 
 	if queryResults.Truncated {
-		fmt.Fprintf(c.out, "# %d row(s) (truncated, max %d)\n", len(queryResults.Rows), queryResults.MaxRows)
+		_, _ = fmt.Fprintf(c.out, "# %d row(s) (truncated, max %d)\n", len(queryResults.Rows), queryResults.MaxRows)
 	}
 	return nil
 }
@@ -287,7 +287,7 @@ func (c *Commands) outputTable(results interface{}) error {
 	}
 
 	if len(queryResults.Rows) == 0 {
-		fmt.Fprintln(c.out, "No results")
+		_, _ = fmt.Fprintln(c.out, "No results")
 		return nil
 	}
 
@@ -296,7 +296,7 @@ func (c *Commands) outputTable(results interface{}) error {
 	tw := tabwriter.NewWriter(c.out, 0, 0, 2, ' ', 0)
 
 	// Header
-	fmt.Fprintln(tw, strings.Join(columns, "\t"))
+	_, _ = fmt.Fprintln(tw, strings.Join(columns, "\t"))
 
 	// Separator
 	seps := make([]string, len(columns))
@@ -310,7 +310,7 @@ func (c *Commands) outputTable(results interface{}) error {
 		}
 		seps[i] = strings.Repeat("-", width)
 	}
-	fmt.Fprintln(tw, strings.Join(seps, "\t"))
+	_, _ = fmt.Fprintln(tw, strings.Join(seps, "\t"))
 
 	// Data rows
 	vals := make([]string, len(columns))
@@ -318,7 +318,7 @@ func (c *Commands) outputTable(results interface{}) error {
 		for i, col := range columns {
 			vals[i] = fmt.Sprintf("%v", row[col])
 		}
-		fmt.Fprintln(tw, strings.Join(vals, "\t"))
+		_, _ = fmt.Fprintln(tw, strings.Join(vals, "\t"))
 	}
 
 	if err := tw.Flush(); err != nil {
@@ -326,9 +326,9 @@ func (c *Commands) outputTable(results interface{}) error {
 	}
 
 	if queryResults.Truncated {
-		fmt.Fprintf(c.out, "\n%d row(s) (truncated, max %d)\n", len(queryResults.Rows), queryResults.MaxRows)
+		_, _ = fmt.Fprintf(c.out, "\n%d row(s) (truncated, max %d)\n", len(queryResults.Rows), queryResults.MaxRows)
 	} else {
-		fmt.Fprintf(c.out, "\n%d row(s)\n", len(queryResults.Rows))
+		_, _ = fmt.Fprintf(c.out, "\n%d row(s)\n", len(queryResults.Rows))
 	}
 	return nil
 }

--- a/internal/cli/commands_test.go
+++ b/internal/cli/commands_test.go
@@ -1,9 +1,11 @@
 package cli
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/tuannvm/mcp-trino/internal/trino"
@@ -80,6 +82,12 @@ func (m *mockTrinoClient) Close() error {
 	return nil
 }
 
+func newTestCommands(client TrinoClient, format string) (*Commands, *bytes.Buffer, *bytes.Buffer) {
+	var stdout, stderr bytes.Buffer
+	cmd := NewCommandsWithWriters(client, format, &stdout, &stderr)
+	return cmd, &stdout, &stderr
+}
+
 func TestNewCommands(t *testing.T) {
 	client := &mockTrinoClient{}
 	cmd := NewCommands(client, "table")
@@ -104,11 +112,16 @@ func TestCommands_Query(t *testing.T) {
 			MaxRows:   10000,
 		},
 	}
-	cmd := NewCommands(client, "table")
+	cmd, stdout, _ := newTestCommands(client, "table")
 
 	err := cmd.Query(ctx, "SELECT * FROM test")
 	if err != nil {
 		t.Fatalf("Query() failed: %v", err)
+	}
+
+	output := stdout.String()
+	if !strings.Contains(output, "col1") || !strings.Contains(output, "value1") {
+		t.Errorf("expected table output with col1/value1, got: %s", output)
 	}
 }
 
@@ -117,7 +130,7 @@ func TestCommands_QueryError(t *testing.T) {
 	client := &mockTrinoClient{
 		queryError: fmt.Errorf("query failed"),
 	}
-	cmd := NewCommands(client, "table")
+	cmd, _, _ := newTestCommands(client, "table")
 
 	err := cmd.Query(ctx, "SELECT * FROM test")
 	if err == nil {
@@ -128,7 +141,7 @@ func TestCommands_QueryError(t *testing.T) {
 func TestCommands_QueryEmpty(t *testing.T) {
 	ctx := context.Background()
 	client := &mockTrinoClient{}
-	cmd := NewCommands(client, "table")
+	cmd, _, _ := newTestCommands(client, "table")
 
 	err := cmd.Query(ctx, "")
 	if err == nil {
@@ -141,11 +154,16 @@ func TestCommands_Catalogs(t *testing.T) {
 	client := &mockTrinoClient{
 		catalogs: []string{"catalog1", "catalog2", "catalog3"},
 	}
-	cmd := NewCommands(client, "table")
+	cmd, stdout, _ := newTestCommands(client, "table")
 
 	err := cmd.Catalogs(ctx)
 	if err != nil {
 		t.Fatalf("Catalogs() failed: %v", err)
+	}
+
+	output := stdout.String()
+	if !strings.Contains(output, "catalog1") {
+		t.Errorf("expected catalog1 in output, got: %s", output)
 	}
 }
 
@@ -154,7 +172,7 @@ func TestCommands_CatalogsError(t *testing.T) {
 	client := &mockTrinoClient{
 		catalogError: fmt.Errorf("catalogs failed"),
 	}
-	cmd := NewCommands(client, "table")
+	cmd, _, _ := newTestCommands(client, "table")
 
 	err := cmd.Catalogs(ctx)
 	if err == nil {
@@ -170,11 +188,16 @@ func TestCommands_Schemas(t *testing.T) {
 			"catalog2": {"schema3"},
 		},
 	}
-	cmd := NewCommands(client, "table")
+	cmd, stdout, _ := newTestCommands(client, "table")
 
 	err := cmd.Schemas(ctx, "catalog1")
 	if err != nil {
 		t.Fatalf("Schemas() failed: %v", err)
+	}
+
+	output := stdout.String()
+	if !strings.Contains(output, "schema1") {
+		t.Errorf("expected schema1 in output, got: %s", output)
 	}
 }
 
@@ -185,9 +208,8 @@ func TestCommands_Schemas_DefaultCatalog(t *testing.T) {
 			"memory": {"default", "information_schema"},
 		},
 	}
-	cmd := NewCommands(client, "table")
+	cmd, _, _ := newTestCommands(client, "table")
 
-	// Test with empty catalog (should use default)
 	_ = os.Setenv("TRINO_CATALOG", "memory")
 	t.Cleanup(func() { _ = os.Unsetenv("TRINO_CATALOG") })
 
@@ -205,11 +227,16 @@ func TestCommands_Tables(t *testing.T) {
 			"catalog2.schema3": {"table3"},
 		},
 	}
-	cmd := NewCommands(client, "table")
+	cmd, stdout, _ := newTestCommands(client, "table")
 
 	err := cmd.Tables(ctx, "catalog1", "schema1")
 	if err != nil {
 		t.Fatalf("Tables() failed: %v", err)
+	}
+
+	output := stdout.String()
+	if !strings.Contains(output, "table1") {
+		t.Errorf("expected table1 in output, got: %s", output)
 	}
 }
 
@@ -220,9 +247,8 @@ func TestCommands_Tables_DefaultCatalogSchema(t *testing.T) {
 			"memory.default": {"table1"},
 		},
 	}
-	cmd := NewCommands(client, "table")
+	cmd, _, _ := newTestCommands(client, "table")
 
-	// Test with empty catalog/schema (should use defaults)
 	_ = os.Setenv("TRINO_CATALOG", "memory")
 	_ = os.Setenv("TRINO_SCHEMA", "default")
 	t.Cleanup(func() {
@@ -248,18 +274,23 @@ func TestCommands_Describe(t *testing.T) {
 			MaxRows:   10000,
 		},
 	}
-	cmd := NewCommands(client, "table")
+	cmd, stdout, _ := newTestCommands(client, "table")
 
 	err := cmd.Describe(ctx, "catalog.schema.table")
 	if err != nil {
 		t.Fatalf("Describe() failed: %v", err)
+	}
+
+	output := stdout.String()
+	if !strings.Contains(output, "col1") || !strings.Contains(output, "varchar") {
+		t.Errorf("expected column info in output, got: %s", output)
 	}
 }
 
 func TestCommands_Describe_EmptyTable(t *testing.T) {
 	ctx := context.Background()
 	client := &mockTrinoClient{}
-	cmd := NewCommands(client, "table")
+	cmd, _, _ := newTestCommands(client, "table")
 
 	err := cmd.Describe(ctx, "")
 	if err == nil {
@@ -278,18 +309,23 @@ func TestCommands_Explain(t *testing.T) {
 			MaxRows:   10000,
 		},
 	}
-	cmd := NewCommands(client, "table")
+	cmd, stdout, _ := newTestCommands(client, "table")
 
 	err := cmd.Explain(ctx, "SELECT * FROM test", "")
 	if err != nil {
 		t.Fatalf("Explain() failed: %v", err)
+	}
+
+	output := stdout.String()
+	if !strings.Contains(output, "Query Plan") {
+		t.Errorf("expected 'Query Plan' in output, got: %s", output)
 	}
 }
 
 func TestCommands_Explain_EmptyQuery(t *testing.T) {
 	ctx := context.Background()
 	client := &mockTrinoClient{}
-	cmd := NewCommands(client, "table")
+	cmd, _, _ := newTestCommands(client, "table")
 
 	err := cmd.Explain(ctx, "", "")
 	if err == nil {
@@ -298,9 +334,9 @@ func TestCommands_Explain_EmptyQuery(t *testing.T) {
 }
 
 func TestOutputJSON(t *testing.T) {
-	cmd := &Commands{format: "json"}
+	cmd, stdout, _ := newTestCommands(&mockTrinoClient{}, "json")
 	data := map[string]interface{}{
-		"key": "value",
+		"key":    "value",
 		"number": 123,
 	}
 
@@ -308,10 +344,15 @@ func TestOutputJSON(t *testing.T) {
 	if err != nil {
 		t.Fatalf("outputJSON() failed: %v", err)
 	}
+
+	output := stdout.String()
+	if !strings.Contains(output, `"key"`) || !strings.Contains(output, `"value"`) {
+		t.Errorf("expected JSON output, got: %s", output)
+	}
 }
 
 func TestOutputTable_EmptyResults(t *testing.T) {
-	cmd := &Commands{format: "table"}
+	cmd, stdout, _ := newTestCommands(&mockTrinoClient{}, "table")
 	result := &trino.QueryResult{
 		Rows:      []map[string]interface{}{},
 		Truncated: false,
@@ -321,11 +362,15 @@ func TestOutputTable_EmptyResults(t *testing.T) {
 	err := cmd.outputTable(result)
 	if err != nil {
 		t.Fatalf("outputTable() failed: %v", err)
+	}
+
+	if !strings.Contains(stdout.String(), "No results") {
+		t.Errorf("expected 'No results', got: %s", stdout.String())
 	}
 }
 
 func TestOutputTable_WithResults(t *testing.T) {
-	cmd := &Commands{format: "table"}
+	cmd, stdout, _ := newTestCommands(&mockTrinoClient{}, "table")
 	result := &trino.QueryResult{
 		Rows: []map[string]interface{}{
 			{"col1": "value1", "col2": 123},
@@ -339,10 +384,18 @@ func TestOutputTable_WithResults(t *testing.T) {
 	if err != nil {
 		t.Fatalf("outputTable() failed: %v", err)
 	}
+
+	output := stdout.String()
+	if !strings.Contains(output, "col1") || !strings.Contains(output, "value1") {
+		t.Errorf("expected table with col1/value1, got: %s", output)
+	}
+	if !strings.Contains(output, "2 row(s)") {
+		t.Errorf("expected row count in output, got: %s", output)
+	}
 }
 
 func TestOutputCSV_EmptyResults(t *testing.T) {
-	cmd := &Commands{format: "csv"}
+	cmd, stdout, _ := newTestCommands(&mockTrinoClient{}, "csv")
 	result := &trino.QueryResult{
 		Rows:      []map[string]interface{}{},
 		Truncated: false,
@@ -353,10 +406,14 @@ func TestOutputCSV_EmptyResults(t *testing.T) {
 	if err != nil {
 		t.Fatalf("outputCSV() failed: %v", err)
 	}
+
+	if !strings.Contains(stdout.String(), "No results") {
+		t.Errorf("expected 'No results', got: %s", stdout.String())
+	}
 }
 
 func TestOutputCSV_WithResults(t *testing.T) {
-	cmd := &Commands{format: "csv"}
+	cmd, stdout, _ := newTestCommands(&mockTrinoClient{}, "csv")
 	result := &trino.QueryResult{
 		Rows: []map[string]interface{}{
 			{"col1": "value1", "col2": 123},
@@ -370,10 +427,15 @@ func TestOutputCSV_WithResults(t *testing.T) {
 	if err != nil {
 		t.Fatalf("outputCSV() failed: %v", err)
 	}
+
+	output := stdout.String()
+	if !strings.Contains(output, "col1") || !strings.Contains(output, "value1") {
+		t.Errorf("expected CSV with col1/value1, got: %s", output)
+	}
 }
 
 func TestFormatOutput_Table(t *testing.T) {
-	cmd := &Commands{format: "table"}
+	cmd, _, _ := newTestCommands(&mockTrinoClient{}, "table")
 	result := &trino.QueryResult{
 		Rows: []map[string]interface{}{
 			{"col1": "value1"},
@@ -389,7 +451,7 @@ func TestFormatOutput_Table(t *testing.T) {
 }
 
 func TestFormatOutput_JSON(t *testing.T) {
-	cmd := &Commands{format: "json"}
+	cmd, _, _ := newTestCommands(&mockTrinoClient{}, "json")
 	result := &trino.QueryResult{
 		Rows: []map[string]interface{}{
 			{"col1": "value1"},
@@ -405,7 +467,7 @@ func TestFormatOutput_JSON(t *testing.T) {
 }
 
 func TestFormatOutput_CSV(t *testing.T) {
-	cmd := &Commands{format: "csv"}
+	cmd, _, _ := newTestCommands(&mockTrinoClient{}, "csv")
 	result := &trino.QueryResult{
 		Rows: []map[string]interface{}{
 			{"col1": "value1", "col2": 123},

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -91,7 +91,10 @@ func migrateYAMLConfig(yamlPath, jsonPath string) (*CLIConfig, error) {
 		return nil, fmt.Errorf("failed to read YAML config: %w", err)
 	}
 
-	cfg := parseSimpleYAML(data)
+	cfg, err := parseSimpleYAML(data)
+	if err != nil {
+		return nil, err
+	}
 	cfg.ConfigPath = jsonPath
 
 	// Ensure profiles exist
@@ -112,7 +115,7 @@ func migrateYAMLConfig(yamlPath, jsonPath string) (*CLIConfig, error) {
 
 // parseSimpleYAML does minimal YAML parsing for the known config structure
 // Handles the two known formats: flat (trino.host) and profiles-based
-func parseSimpleYAML(data []byte) *CLIConfig {
+func parseSimpleYAML(data []byte) (*CLIConfig, error) {
 	cfg := &CLIConfig{
 		Profiles: make(map[string]TrinoProfileConfig),
 	}
@@ -209,7 +212,12 @@ func parseSimpleYAML(data []byte) *CLIConfig {
 		}
 	}
 
-	return cfg
+	// Validate that we parsed something meaningful from non-empty input
+	if len(data) > 0 && len(cfg.Profiles) == 0 && cfg.Current == "" && cfg.Output.Format == "" {
+		return nil, fmt.Errorf("failed to parse YAML config: no valid configuration found")
+	}
+
+	return cfg, nil
 }
 
 // cleanYAMLValue strips YAML quoting and inline comments from a value
@@ -277,7 +285,10 @@ func ParseCLIConfigWithPath(data []byte, configPath string) (*CLIConfig, error) 
 
 // ParseYAMLConfigWithPath parses a legacy YAML config and sets the config path
 func ParseYAMLConfigWithPath(data []byte, configPath string) (*CLIConfig, error) {
-	cfg := parseSimpleYAML(data)
+	cfg, err := parseSimpleYAML(data)
+	if err != nil {
+		return nil, err
+	}
 	cfg.ConfigPath = configPath
 	if len(cfg.Profiles) == 0 {
 		cfg.Profiles = defaultCLIConfig().Profiles

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -7,43 +7,53 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+
+	"gopkg.in/yaml.v3"
 )
 
 // TrinoProfileConfig represents a single Trino connection profile
 type TrinoProfileConfig struct {
-	Host     string    `json:"host"`
-	Port     int       `json:"port"`
-	User     string    `json:"user"`
-	Password string    `json:"password,omitempty"`
-	Catalog  string    `json:"catalog,omitempty"`
-	Schema   string    `json:"schema,omitempty"`
-	Source   string    `json:"source,omitempty"`
-	SSL      SSLConfig `json:"ssl,omitempty"`
+	Host     string    `json:"host" yaml:"host"`
+	Port     int       `json:"port" yaml:"port"`
+	User     string    `json:"user" yaml:"user"`
+	Password string    `json:"password,omitempty" yaml:"password,omitempty"`
+	Catalog  string    `json:"catalog,omitempty" yaml:"catalog,omitempty"`
+	Schema   string    `json:"schema,omitempty" yaml:"schema,omitempty"`
+	Source   string    `json:"source,omitempty" yaml:"source,omitempty"`
+	SSL      SSLConfig `json:"ssl,omitempty" yaml:"ssl,omitempty"`
 }
 
 // SSLConfig holds SSL configuration for a profile
 type SSLConfig struct {
-	Enabled  *bool `json:"enabled,omitempty"` // pointer to distinguish unset vs false
-	Insecure bool  `json:"insecure,omitempty"`
+	Enabled  *bool `json:"enabled,omitempty" yaml:"enabled,omitempty"` // pointer to distinguish unset vs false
+	Insecure bool  `json:"insecure,omitempty" yaml:"insecure,omitempty"`
 }
 
-// CLIConfig represents the JSON configuration file structure
+// CLIConfig represents the configuration file structure (JSON or YAML)
 type CLIConfig struct {
-	// ConfigPath tracks where this config was loaded from (not saved to JSON)
-	ConfigPath string `json:"-"`
+	// ConfigPath tracks where this config was loaded from (not serialized)
+	ConfigPath string `json:"-" yaml:"-"`
 
-	Current  string                        `json:"current"`            // default profile name
-	Profiles map[string]TrinoProfileConfig `json:"profiles"`           // connection profiles
-	Output   OutputConfig                  `json:"output,omitempty"`   // output settings
+	Current  string                        `json:"current" yaml:"current"`
+	Profiles map[string]TrinoProfileConfig `json:"profiles" yaml:"profiles"`
+	Output   OutputConfig                  `json:"output,omitempty" yaml:"output,omitempty"`
+
+	// Legacy flat config (YAML only, read-only — auto-migrated to profiles on load, never serialized)
+	Trino *TrinoProfileConfig `json:"-" yaml:"trino,omitempty"`
 }
 
 // OutputConfig holds output formatting configuration
 type OutputConfig struct {
-	Format string `json:"format,omitempty"` // table, json, csv
+	Format string `json:"format,omitempty" yaml:"format,omitempty"` // table, json, csv
 }
 
-// LoadCLIConfig loads the CLI configuration from ~/.config/trino/config.json
-// Falls back to reading legacy ~/.config/trino/config.yaml if JSON doesn't exist
+// isYAMLPath returns true if the path has a .yaml or .yml extension
+func isYAMLPath(path string) bool {
+	return strings.HasSuffix(path, ".yaml") || strings.HasSuffix(path, ".yml")
+}
+
+// LoadCLIConfig loads the CLI configuration from ~/.config/trino/
+// Tries config.json first, then config.yaml. Both formats are supported natively.
 func LoadCLIConfig() (*CLIConfig, error) {
 	homeDir, err := os.UserHomeDir()
 	if err != nil {
@@ -54,228 +64,57 @@ func LoadCLIConfig() (*CLIConfig, error) {
 	jsonPath := filepath.Join(configDir, "config.json")
 	yamlPath := filepath.Join(configDir, "config.yaml")
 
-	// Try JSON config first
+	// Try JSON first
 	if _, err := os.Stat(jsonPath); err == nil {
-		data, readErr := os.ReadFile(jsonPath)
-		if readErr != nil {
-			return nil, fmt.Errorf("failed to read config file: %w", readErr)
-		}
-		cfg, parseErr := parseCLIConfigFromJSON(data)
-		if parseErr != nil {
-			return nil, parseErr
-		}
-		cfg.ConfigPath = jsonPath
-		return cfg, nil
+		return loadConfigFromFile(jsonPath)
 	}
 
-	// Fall back to legacy YAML config and auto-migrate to JSON
+	// Try YAML
 	if _, err := os.Stat(yamlPath); err == nil {
-		cfg, migrateErr := migrateYAMLConfig(yamlPath, jsonPath)
-		if migrateErr != nil {
-			return nil, fmt.Errorf("failed to migrate YAML config: %w", migrateErr)
-		}
-		return cfg, nil
+		return loadConfigFromFile(yamlPath)
 	}
 
-	// No config file — return defaults
+	// No config file — return defaults with JSON path
 	cfg := defaultCLIConfig()
 	cfg.ConfigPath = jsonPath
 	return cfg, nil
 }
 
-// migrateYAMLConfig reads a legacy YAML config, converts it to JSON, and saves it
-// YAML is parsed with minimal stdlib-only support for the known config structure
-func migrateYAMLConfig(yamlPath, jsonPath string) (*CLIConfig, error) {
-	data, err := os.ReadFile(yamlPath)
+// loadConfigFromFile reads and parses a config file, detecting format by extension
+func loadConfigFromFile(path string) (*CLIConfig, error) {
+	data, err := os.ReadFile(path)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read YAML config: %w", err)
+		return nil, fmt.Errorf("failed to read config file: %w", err)
 	}
 
-	cfg, err := parseSimpleYAML(data)
+	var cfg *CLIConfig
+	if isYAMLPath(path) {
+		cfg, err = parseYAMLConfig(data)
+	} else {
+		cfg, err = parseJSONConfig(data)
+	}
 	if err != nil {
 		return nil, err
 	}
-	cfg.ConfigPath = jsonPath
 
-	// Ensure profiles exist
-	if len(cfg.Profiles) == 0 {
-		cfg.Profiles = defaultCLIConfig().Profiles
-		if cfg.Current == "" {
-			cfg.Current = "default"
-		}
-	}
-
-	// Save as JSON
-	if err := SaveCLIConfig(cfg); err != nil {
-		return nil, fmt.Errorf("failed to save migrated config: %w", err)
-	}
-
+	cfg.ConfigPath = path
 	return cfg, nil
-}
-
-// parseSimpleYAML does minimal YAML parsing for the known config structure
-// Handles the two known formats: flat (trino.host) and profiles-based
-func parseSimpleYAML(data []byte) (*CLIConfig, error) {
-	cfg := &CLIConfig{
-		Profiles: make(map[string]TrinoProfileConfig),
-	}
-
-	lines := strings.Split(string(data), "\n")
-	var currentSection string
-	var currentProfile string
-	var currentSubsection string
-
-	for _, line := range lines {
-		trimmed := strings.TrimSpace(line)
-		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
-			continue
-		}
-
-		// Count leading spaces for indent level
-		indent := len(line) - len(strings.TrimLeft(line, " \t"))
-
-		// Parse key: value
-		parts := strings.SplitN(trimmed, ":", 2)
-		if len(parts) != 2 {
-			continue
-		}
-		key := strings.TrimSpace(parts[0])
-		value := cleanYAMLValue(strings.TrimSpace(parts[1]))
-
-		if indent == 0 {
-			currentSection = key
-			currentSubsection = ""
-			currentProfile = ""
-			if key == "current" && value != "" {
-				cfg.Current = value
-			}
-			continue
-		}
-
-		switch currentSection {
-		case "trino":
-			// Legacy flat config — populate a "default" profile
-			if _, exists := cfg.Profiles["default"]; !exists {
-				cfg.Profiles["default"] = TrinoProfileConfig{}
-			}
-			p := cfg.Profiles["default"]
-			// Reset subsection when returning to profile-level indent
-			if currentSubsection == "ssl" && indent <= 2 {
-				currentSubsection = ""
-			}
-			if key == "ssl" && value == "" {
-				currentSubsection = "ssl"
-				cfg.Profiles["default"] = p
-				continue
-			}
-			if currentSubsection == "ssl" {
-				applySSLField(&p, key, value)
-			} else {
-				applyProfileField(&p, key, value)
-			}
-			cfg.Profiles["default"] = p
-			if cfg.Current == "" {
-				cfg.Current = "default"
-			}
-
-		case "profiles":
-			if indent == 2 && value == "" {
-				// Profile name header
-				currentProfile = key
-				cfg.Profiles[currentProfile] = TrinoProfileConfig{}
-				currentSubsection = ""
-				continue
-			}
-			if currentProfile != "" {
-				p := cfg.Profiles[currentProfile]
-				// Reset subsection when returning to profile-field indent
-				if currentSubsection == "ssl" && indent <= 4 {
-					currentSubsection = ""
-				}
-				if key == "ssl" && value == "" {
-					currentSubsection = "ssl"
-					cfg.Profiles[currentProfile] = p
-					continue
-				}
-				if currentSubsection == "ssl" {
-					applySSLField(&p, key, value)
-				} else {
-					applyProfileField(&p, key, value)
-				}
-				cfg.Profiles[currentProfile] = p
-			}
-
-		case "output":
-			if key == "format" && value != "" {
-				cfg.Output.Format = value
-			}
-		}
-	}
-
-	// Validate that we parsed something meaningful from non-empty input
-	if len(data) > 0 && len(cfg.Profiles) == 0 && cfg.Current == "" && cfg.Output.Format == "" {
-		return nil, fmt.Errorf("failed to parse YAML config: no valid configuration found")
-	}
-
-	return cfg, nil
-}
-
-// cleanYAMLValue strips YAML quoting and inline comments from a value
-func cleanYAMLValue(v string) string {
-	// Strip inline comments (only outside quotes)
-	if !strings.HasPrefix(v, "'") && !strings.HasPrefix(v, "\"") {
-		if idx := strings.Index(v, " #"); idx >= 0 {
-			v = strings.TrimSpace(v[:idx])
-		}
-	}
-	// Strip surrounding quotes
-	if len(v) >= 2 {
-		if (v[0] == '"' && v[len(v)-1] == '"') || (v[0] == '\'' && v[len(v)-1] == '\'') {
-			v = v[1 : len(v)-1]
-		}
-	}
-	return v
-}
-
-func applyProfileField(p *TrinoProfileConfig, key, value string) {
-	switch key {
-	case "host":
-		p.Host = value
-	case "port":
-		if n, err := fmt.Sscanf(value, "%d", &p.Port); n == 0 || err != nil {
-			p.Port = 0
-		}
-	case "user":
-		p.User = value
-	case "password":
-		p.Password = value
-	case "catalog":
-		p.Catalog = value
-	case "schema":
-		p.Schema = value
-	case "source":
-		p.Source = value
-	}
-}
-
-func applySSLField(p *TrinoProfileConfig, key, value string) {
-	switch key {
-	case "enabled":
-		b := value == "true"
-		p.SSL.Enabled = &b
-	case "insecure":
-		p.SSL.Insecure = value == "true"
-	}
 }
 
 // ParseCLIConfig parses CLI configuration from JSON data
 func ParseCLIConfig(data []byte) (*CLIConfig, error) {
-	return parseCLIConfigFromJSON(data)
+	return parseJSONConfig(data)
 }
 
-// ParseCLIConfigWithPath parses CLI configuration from JSON data and sets the config path
+// ParseCLIConfigWithPath parses CLI configuration from data, detecting format by path extension
 func ParseCLIConfigWithPath(data []byte, configPath string) (*CLIConfig, error) {
-	cfg, err := parseCLIConfigFromJSON(data)
+	var cfg *CLIConfig
+	var err error
+	if isYAMLPath(configPath) {
+		cfg, err = parseYAMLConfig(data)
+	} else {
+		cfg, err = parseJSONConfig(data)
+	}
 	if err != nil {
 		return nil, err
 	}
@@ -283,44 +122,51 @@ func ParseCLIConfigWithPath(data []byte, configPath string) (*CLIConfig, error) 
 	return cfg, nil
 }
 
-// ParseYAMLConfigWithPath parses a legacy YAML config and sets the config path
-func ParseYAMLConfigWithPath(data []byte, configPath string) (*CLIConfig, error) {
-	cfg, err := parseSimpleYAML(data)
-	if err != nil {
-		return nil, err
-	}
-	cfg.ConfigPath = configPath
-	if len(cfg.Profiles) == 0 {
-		cfg.Profiles = defaultCLIConfig().Profiles
-		if cfg.Current == "" {
-			cfg.Current = "default"
-		}
-	}
-	return cfg, nil
-}
-
-// parseCLIConfigFromJSON parses and normalizes a JSON config
-func parseCLIConfigFromJSON(data []byte) (*CLIConfig, error) {
+// parseJSONConfig parses and normalizes a JSON config
+func parseJSONConfig(data []byte) (*CLIConfig, error) {
 	var cfg CLIConfig
 	if len(data) > 0 {
 		if err := json.Unmarshal(data, &cfg); err != nil {
-			return nil, fmt.Errorf("failed to parse config file: %w", err)
+			return nil, fmt.Errorf("failed to parse JSON config: %w", err)
 		}
 	}
+	normalizeConfig(&cfg)
+	return &cfg, nil
+}
 
-	// Ensure profiles map exists with defaults
+// parseYAMLConfig parses and normalizes a YAML config
+func parseYAMLConfig(data []byte) (*CLIConfig, error) {
+	var cfg CLIConfig
+	if len(data) > 0 {
+		if err := yaml.Unmarshal(data, &cfg); err != nil {
+			return nil, fmt.Errorf("failed to parse YAML config: %w", err)
+		}
+	}
+	// Migrate legacy flat "trino:" section to profiles
+	if cfg.Trino != nil && len(cfg.Profiles) == 0 {
+		cfg.Profiles = map[string]TrinoProfileConfig{
+			"default": *cfg.Trino,
+		}
+		if cfg.Current == "" {
+			cfg.Current = "default"
+		}
+		cfg.Trino = nil
+	}
+	normalizeConfig(&cfg)
+	return &cfg, nil
+}
+
+// normalizeConfig ensures a config has valid defaults
+func normalizeConfig(cfg *CLIConfig) {
 	if len(cfg.Profiles) == 0 {
 		cfg.Profiles = defaultCLIConfig().Profiles
 		if cfg.Current == "" {
 			cfg.Current = "default"
 		}
 	}
-
-	return &cfg, nil
 }
 
-// SaveCLIConfig saves the CLI configuration to the path it was loaded from,
-// or to ~/.config/trino/config.json if no path was set
+// SaveCLIConfig saves the CLI configuration, using the format matching ConfigPath extension
 func SaveCLIConfig(cfg *CLIConfig) error {
 	configPath := cfg.ConfigPath
 	if configPath == "" {
@@ -331,12 +177,21 @@ func SaveCLIConfig(cfg *CLIConfig) error {
 		configPath = filepath.Join(homeDir, ".config", "trino", "config.json")
 	}
 
-	// Create config directory if it doesn't exist
 	if err := os.MkdirAll(filepath.Dir(configPath), 0755); err != nil {
 		return fmt.Errorf("failed to create config directory: %w", err)
 	}
 
-	data, err := json.MarshalIndent(cfg, "", "  ")
+	// Shallow copy to avoid mutating caller; clear legacy field before serializing
+	toSave := *cfg
+	toSave.Trino = nil
+
+	var data []byte
+	var err error
+	if isYAMLPath(configPath) {
+		data, err = yaml.Marshal(&toSave)
+	} else {
+		data, err = json.MarshalIndent(&toSave, "", "  ")
+	}
 	if err != nil {
 		return fmt.Errorf("failed to marshal config: %w", err)
 	}
@@ -354,7 +209,6 @@ func DefaultCLIConfig() *CLIConfig {
 	return defaultCLIConfig()
 }
 
-// defaultCLIConfig returns a default CLI configuration
 func defaultCLIConfig() *CLIConfig {
 	return &CLIConfig{
 		Current: "default",
@@ -373,10 +227,7 @@ func defaultCLIConfig() *CLIConfig {
 	}
 }
 
-// GetActiveProfile returns the active profile based on precedence:
-// 1. Explicit profile name (from --profile flag or TRINO_PROFILE env)
-// 2. Current field in config
-// 3. "default" profile fallback
+// GetActiveProfile returns the active profile based on precedence
 func (c *CLIConfig) GetActiveProfile(profileName string) (*TrinoProfileConfig, error) {
 	name := c.resolveProfileName(profileName)
 
@@ -389,7 +240,6 @@ func (c *CLIConfig) GetActiveProfile(profileName string) (*TrinoProfileConfig, e
 	return &profile, nil
 }
 
-// resolveProfileName determines the active profile name based on precedence
 func (c *CLIConfig) resolveProfileName(explicitName string) string {
 	if explicitName != "" {
 		return explicitName
@@ -400,7 +250,6 @@ func (c *CLIConfig) resolveProfileName(explicitName string) string {
 	return "default"
 }
 
-// getProfileNames returns a sorted list of profile names
 func (c *CLIConfig) getProfileNames() []string {
 	names := make([]string, 0, len(c.Profiles))
 	for name := range c.Profiles {
@@ -415,7 +264,7 @@ func (c *CLIConfig) GetProfileNames() []string {
 	return c.getProfileNames()
 }
 
-// Validate validates the config (e.g., current profile exists)
+// Validate validates the config
 func (c *CLIConfig) Validate() error {
 	if c.Current != "" {
 		if _, exists := c.Profiles[c.Current]; !exists {
@@ -450,8 +299,6 @@ func (c *CLIConfig) SetCurrent(name string) error {
 }
 
 // ApplyToEnv applies CLI config to environment variables
-// This applies the active profile values to env vars (profiles override existing env vars)
-// CLI flags will later override these env vars (highest priority)
 func (c *CLIConfig) ApplyToEnv(profileName string) error {
 	profile, err := c.GetActiveProfile(profileName)
 	if err != nil {
@@ -484,7 +331,6 @@ func (c *CLIConfig) GetOutputFormat() string {
 	return c.Output.Format
 }
 
-// setEnvIfValue sets an environment variable to the given value (if non-empty)
 func setEnvIfValue(key, value string) {
 	if value == "" {
 		return

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -1,88 +1,100 @@
 package cli
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
-
-	"gopkg.in/yaml.v3"
+	"sort"
+	"strings"
 )
 
 // TrinoProfileConfig represents a single Trino connection profile
 type TrinoProfileConfig struct {
-	Host     string `yaml:"host"`
-	Port     int    `yaml:"port"`
-	User     string `yaml:"user"`
-	Password string `yaml:"password"`
-	Catalog  string `yaml:"catalog"`
-	Schema   string `yaml:"schema"`
-	Source   string `yaml:"source"`
-	SSL      struct {
-		Enabled  *bool `yaml:"enabled"` // pointer to distinguish unset vs false
-		Insecure bool  `yaml:"insecure"`
-	} `yaml:"ssl"`
+	Host     string    `json:"host"`
+	Port     int       `json:"port"`
+	User     string    `json:"user"`
+	Password string    `json:"password,omitempty"`
+	Catalog  string    `json:"catalog,omitempty"`
+	Schema   string    `json:"schema,omitempty"`
+	Source   string    `json:"source,omitempty"`
+	SSL      SSLConfig `json:"ssl,omitempty"`
 }
 
-// CLIConfig represents the YAML configuration file structure
+// SSLConfig holds SSL configuration for a profile
+type SSLConfig struct {
+	Enabled  *bool `json:"enabled,omitempty"` // pointer to distinguish unset vs false
+	Insecure bool  `json:"insecure,omitempty"`
+}
+
+// CLIConfig represents the JSON configuration file structure
 type CLIConfig struct {
-	// ConfigPath tracks where this config was loaded from (not saved to YAML)
-	ConfigPath string `yaml:"-"`
+	// ConfigPath tracks where this config was loaded from (not saved to JSON)
+	ConfigPath string `json:"-"`
 
-	Current  string                       `yaml:"current"` // default profile name
-	Profiles map[string]TrinoProfileConfig `yaml:"profiles"`
-	Output   struct {
-		Format string `yaml:"format"` // table, json, csv
-	} `yaml:"output"`
-
-	// Legacy fields for backward compatibility (auto-migrated to profiles)
-	Trino struct {
-		Host     string `yaml:"host"`
-		Port     int    `yaml:"port"`
-		User     string `yaml:"user"`
-		Password string `yaml:"password"`
-		Catalog  string `yaml:"catalog"`
-		Schema   string `yaml:"schema"`
-		Source   string `yaml:"source"`
-		SSL      struct {
-			Enabled  *bool `yaml:"enabled"` // pointer to distinguish unset vs false
-			Insecure bool  `yaml:"insecure"`
-		} `yaml:"ssl"`
-	} `yaml:"trino"`
+	Current  string                        `json:"current"`            // default profile name
+	Profiles map[string]TrinoProfileConfig `json:"profiles"`           // connection profiles
+	Output   OutputConfig                  `json:"output,omitempty"`   // output settings
 }
 
-// LoadCLIConfig loads the CLI configuration from ~/.config/trino/config.yaml
+// OutputConfig holds output formatting configuration
+type OutputConfig struct {
+	Format string `json:"format,omitempty"` // table, json, csv
+}
+
+// LoadCLIConfig loads the CLI configuration from ~/.config/trino/config.json
+// Falls back to reading legacy ~/.config/trino/config.yaml if JSON doesn't exist
 func LoadCLIConfig() (*CLIConfig, error) {
-	// Use XDG config directory: ~/.config/trino/config.yaml
 	homeDir, err := os.UserHomeDir()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get home directory: %w", err)
 	}
 
-	configPath := filepath.Join(homeDir, ".config", "trino", "config.yaml")
+	configDir := filepath.Join(homeDir, ".config", "trino")
+	jsonPath := filepath.Join(configDir, "config.json")
+	yamlPath := filepath.Join(configDir, "config.yaml")
 
-	// If config doesn't exist, return default config
-	if _, err := os.Stat(configPath); os.IsNotExist(err) {
-		cfg := defaultCLIConfig()
-		cfg.ConfigPath = configPath
+	// Try JSON config first
+	if _, err := os.Stat(jsonPath); err == nil {
+		data, readErr := os.ReadFile(jsonPath)
+		if readErr != nil {
+			return nil, fmt.Errorf("failed to read config file: %w", readErr)
+		}
+		cfg, parseErr := parseCLIConfigFromJSON(data)
+		if parseErr != nil {
+			return nil, parseErr
+		}
+		cfg.ConfigPath = jsonPath
 		return cfg, nil
 	}
 
-	data, err := os.ReadFile(configPath)
+	// Fall back to legacy YAML config and auto-migrate to JSON
+	if _, err := os.Stat(yamlPath); err == nil {
+		cfg, migrateErr := migrateYAMLConfig(yamlPath, jsonPath)
+		if migrateErr != nil {
+			return nil, fmt.Errorf("failed to migrate YAML config: %w", migrateErr)
+		}
+		return cfg, nil
+	}
+
+	// No config file — return defaults
+	cfg := defaultCLIConfig()
+	cfg.ConfigPath = jsonPath
+	return cfg, nil
+}
+
+// migrateYAMLConfig reads a legacy YAML config, converts it to JSON, and saves it
+// YAML is parsed with minimal stdlib-only support for the known config structure
+func migrateYAMLConfig(yamlPath, jsonPath string) (*CLIConfig, error) {
+	data, err := os.ReadFile(yamlPath)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read config file: %w", err)
+		return nil, fmt.Errorf("failed to read YAML config: %w", err)
 	}
 
-	var cfg CLIConfig
-	if err := yaml.Unmarshal(data, &cfg); err != nil {
-		return nil, fmt.Errorf("failed to parse config file: %w", err)
-	}
+	cfg := parseSimpleYAML(data)
+	cfg.ConfigPath = jsonPath
 
-	// Auto-migrate legacy flat config to profiles
-	if err := cfg.migrateLegacyConfig(); err != nil {
-		return nil, fmt.Errorf("failed to migrate legacy config: %w", err)
-	}
-
-	// If no profiles exist after migration, ensure we have a default profile
+	// Ensure profiles exist
 	if len(cfg.Profiles) == 0 {
 		cfg.Profiles = defaultCLIConfig().Profiles
 		if cfg.Current == "" {
@@ -90,65 +102,222 @@ func LoadCLIConfig() (*CLIConfig, error) {
 		}
 	}
 
-	cfg.ConfigPath = configPath
-	return &cfg, nil
+	// Save as JSON
+	if err := SaveCLIConfig(cfg); err != nil {
+		return nil, fmt.Errorf("failed to save migrated config: %w", err)
+	}
+
+	return cfg, nil
 }
 
-// ParseCLIConfig parses CLI configuration from YAML data
+// parseSimpleYAML does minimal YAML parsing for the known config structure
+// Handles the two known formats: flat (trino.host) and profiles-based
+func parseSimpleYAML(data []byte) *CLIConfig {
+	cfg := &CLIConfig{
+		Profiles: make(map[string]TrinoProfileConfig),
+	}
+
+	lines := strings.Split(string(data), "\n")
+	var currentSection string
+	var currentProfile string
+	var currentSubsection string
+
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+
+		// Count leading spaces for indent level
+		indent := len(line) - len(strings.TrimLeft(line, " \t"))
+
+		// Parse key: value
+		parts := strings.SplitN(trimmed, ":", 2)
+		if len(parts) != 2 {
+			continue
+		}
+		key := strings.TrimSpace(parts[0])
+		value := cleanYAMLValue(strings.TrimSpace(parts[1]))
+
+		if indent == 0 {
+			currentSection = key
+			currentSubsection = ""
+			currentProfile = ""
+			if key == "current" && value != "" {
+				cfg.Current = value
+			}
+			continue
+		}
+
+		switch currentSection {
+		case "trino":
+			// Legacy flat config — populate a "default" profile
+			if _, exists := cfg.Profiles["default"]; !exists {
+				cfg.Profiles["default"] = TrinoProfileConfig{}
+			}
+			p := cfg.Profiles["default"]
+			// Reset subsection when returning to profile-level indent
+			if currentSubsection == "ssl" && indent <= 2 {
+				currentSubsection = ""
+			}
+			if key == "ssl" && value == "" {
+				currentSubsection = "ssl"
+				cfg.Profiles["default"] = p
+				continue
+			}
+			if currentSubsection == "ssl" {
+				applySSLField(&p, key, value)
+			} else {
+				applyProfileField(&p, key, value)
+			}
+			cfg.Profiles["default"] = p
+			if cfg.Current == "" {
+				cfg.Current = "default"
+			}
+
+		case "profiles":
+			if indent == 2 && value == "" {
+				// Profile name header
+				currentProfile = key
+				cfg.Profiles[currentProfile] = TrinoProfileConfig{}
+				currentSubsection = ""
+				continue
+			}
+			if currentProfile != "" {
+				p := cfg.Profiles[currentProfile]
+				// Reset subsection when returning to profile-field indent
+				if currentSubsection == "ssl" && indent <= 4 {
+					currentSubsection = ""
+				}
+				if key == "ssl" && value == "" {
+					currentSubsection = "ssl"
+					cfg.Profiles[currentProfile] = p
+					continue
+				}
+				if currentSubsection == "ssl" {
+					applySSLField(&p, key, value)
+				} else {
+					applyProfileField(&p, key, value)
+				}
+				cfg.Profiles[currentProfile] = p
+			}
+
+		case "output":
+			if key == "format" && value != "" {
+				cfg.Output.Format = value
+			}
+		}
+	}
+
+	return cfg
+}
+
+// cleanYAMLValue strips YAML quoting and inline comments from a value
+func cleanYAMLValue(v string) string {
+	// Strip inline comments (only outside quotes)
+	if !strings.HasPrefix(v, "'") && !strings.HasPrefix(v, "\"") {
+		if idx := strings.Index(v, " #"); idx >= 0 {
+			v = strings.TrimSpace(v[:idx])
+		}
+	}
+	// Strip surrounding quotes
+	if len(v) >= 2 {
+		if (v[0] == '"' && v[len(v)-1] == '"') || (v[0] == '\'' && v[len(v)-1] == '\'') {
+			v = v[1 : len(v)-1]
+		}
+	}
+	return v
+}
+
+func applyProfileField(p *TrinoProfileConfig, key, value string) {
+	switch key {
+	case "host":
+		p.Host = value
+	case "port":
+		if n, err := fmt.Sscanf(value, "%d", &p.Port); n == 0 || err != nil {
+			p.Port = 0
+		}
+	case "user":
+		p.User = value
+	case "password":
+		p.Password = value
+	case "catalog":
+		p.Catalog = value
+	case "schema":
+		p.Schema = value
+	case "source":
+		p.Source = value
+	}
+}
+
+func applySSLField(p *TrinoProfileConfig, key, value string) {
+	switch key {
+	case "enabled":
+		b := value == "true"
+		p.SSL.Enabled = &b
+	case "insecure":
+		p.SSL.Insecure = value == "true"
+	}
+}
+
+// ParseCLIConfig parses CLI configuration from JSON data
 func ParseCLIConfig(data []byte) (*CLIConfig, error) {
-	var cfg CLIConfig
-	if err := yaml.Unmarshal(data, &cfg); err != nil {
-		return nil, fmt.Errorf("failed to parse config file: %w", err)
-	}
-	// Auto-migrate legacy flat config to profiles for custom config files too
-	if err := cfg.migrateLegacyConfig(); err != nil {
-		return nil, fmt.Errorf("failed to migrate legacy config: %w", err)
-	}
-	// If no profiles exist after migration, ensure we have a default profile
-	if len(cfg.Profiles) == 0 {
-		cfg.Profiles = defaultCLIConfig().Profiles
-		if cfg.Current == "" {
-			cfg.Current = "default"
-		}
-	}
-	return &cfg, nil
+	return parseCLIConfigFromJSON(data)
 }
 
-// ParseCLIConfigWithPath parses CLI configuration from YAML data and sets the config path
+// ParseCLIConfigWithPath parses CLI configuration from JSON data and sets the config path
 func ParseCLIConfigWithPath(data []byte, configPath string) (*CLIConfig, error) {
-	var cfg CLIConfig
-	if err := yaml.Unmarshal(data, &cfg); err != nil {
-		return nil, fmt.Errorf("failed to parse config file: %w", err)
+	cfg, err := parseCLIConfigFromJSON(data)
+	if err != nil {
+		return nil, err
 	}
-	// Set ConfigPath before migration so it saves to the correct location
 	cfg.ConfigPath = configPath
-	// Auto-migrate legacy flat config to profiles
-	if err := cfg.migrateLegacyConfig(); err != nil {
-		return nil, fmt.Errorf("failed to migrate legacy config: %w", err)
-	}
-	// If no profiles exist after migration, ensure we have a default profile
+	return cfg, nil
+}
+
+// ParseYAMLConfigWithPath parses a legacy YAML config and sets the config path
+func ParseYAMLConfigWithPath(data []byte, configPath string) (*CLIConfig, error) {
+	cfg := parseSimpleYAML(data)
+	cfg.ConfigPath = configPath
 	if len(cfg.Profiles) == 0 {
 		cfg.Profiles = defaultCLIConfig().Profiles
 		if cfg.Current == "" {
 			cfg.Current = "default"
 		}
 	}
+	return cfg, nil
+}
+
+// parseCLIConfigFromJSON parses and normalizes a JSON config
+func parseCLIConfigFromJSON(data []byte) (*CLIConfig, error) {
+	var cfg CLIConfig
+	if len(data) > 0 {
+		if err := json.Unmarshal(data, &cfg); err != nil {
+			return nil, fmt.Errorf("failed to parse config file: %w", err)
+		}
+	}
+
+	// Ensure profiles map exists with defaults
+	if len(cfg.Profiles) == 0 {
+		cfg.Profiles = defaultCLIConfig().Profiles
+		if cfg.Current == "" {
+			cfg.Current = "default"
+		}
+	}
+
 	return &cfg, nil
 }
 
 // SaveCLIConfig saves the CLI configuration to the path it was loaded from,
-// or to ~/.config/trino/config.yaml if no path was set
+// or to ~/.config/trino/config.json if no path was set
 func SaveCLIConfig(cfg *CLIConfig) error {
-	var configPath string
-	if cfg.ConfigPath != "" {
-		configPath = cfg.ConfigPath
-	} else {
-		// Use XDG config directory: ~/.config/trino/config.yaml
+	configPath := cfg.ConfigPath
+	if configPath == "" {
 		homeDir, err := os.UserHomeDir()
 		if err != nil {
 			return fmt.Errorf("failed to get home directory: %w", err)
 		}
-		configPath = filepath.Join(homeDir, ".config", "trino", "config.yaml")
+		configPath = filepath.Join(homeDir, ".config", "trino", "config.json")
 	}
 
 	// Create config directory if it doesn't exist
@@ -156,10 +325,11 @@ func SaveCLIConfig(cfg *CLIConfig) error {
 		return fmt.Errorf("failed to create config directory: %w", err)
 	}
 
-	data, err := yaml.Marshal(cfg)
+	data, err := json.MarshalIndent(cfg, "", "  ")
 	if err != nil {
 		return fmt.Errorf("failed to marshal config: %w", err)
 	}
+	data = append(data, '\n')
 
 	if err := os.WriteFile(configPath, data, 0600); err != nil {
 		return fmt.Errorf("failed to write config file: %w", err)
@@ -186,58 +356,10 @@ func defaultCLIConfig() *CLIConfig {
 				Schema:  "default",
 			},
 		},
-		Output: struct {
-			Format string `yaml:"format"`
-		}{
+		Output: OutputConfig{
 			Format: "table",
 		},
 	}
-}
-
-// migrateLegacyConfig migrates old flat trino config to profiles structure
-func (c *CLIConfig) migrateLegacyConfig() error {
-	// Check if we have legacy flat config (has trino.host but no profiles)
-	hasLegacyConfig := c.Trino.Host != ""
-	hasProfiles := len(c.Profiles) > 0
-
-	if hasLegacyConfig && !hasProfiles {
-		// Migrate legacy config to "default" profile
-		c.Profiles = map[string]TrinoProfileConfig{
-			"default": {
-				Host:     c.Trino.Host,
-				Port:     c.Trino.Port,
-				User:     c.Trino.User,
-				Password: c.Trino.Password,
-				Catalog:  c.Trino.Catalog,
-				Schema:   c.Trino.Schema,
-				Source:   c.Trino.Source,
-				SSL:      c.Trino.SSL,
-			},
-		}
-		// Set current to default if not already set
-		if c.Current == "" {
-			c.Current = "default"
-		}
-		// Clear legacy config (not strictly necessary but clean)
-		c.Trino = struct {
-			Host     string `yaml:"host"`
-			Port     int    `yaml:"port"`
-			User     string `yaml:"user"`
-			Password string `yaml:"password"`
-			Catalog  string `yaml:"catalog"`
-			Schema   string `yaml:"schema"`
-			Source   string `yaml:"source"`
-			SSL      struct {
-				Enabled  *bool `yaml:"enabled"`
-				Insecure bool  `yaml:"insecure"`
-			} `yaml:"ssl"`
-		}{}
-		// Save the migrated config
-		if err := SaveCLIConfig(c); err != nil {
-			return fmt.Errorf("failed to save migrated config: %w", err)
-		}
-	}
-	return nil
 }
 
 // GetActiveProfile returns the active profile based on precedence:
@@ -245,10 +367,8 @@ func (c *CLIConfig) migrateLegacyConfig() error {
 // 2. Current field in config
 // 3. "default" profile fallback
 func (c *CLIConfig) GetActiveProfile(profileName string) (*TrinoProfileConfig, error) {
-	// Determine which profile to use
 	name := c.resolveProfileName(profileName)
 
-	// Validate profile exists
 	profile, exists := c.Profiles[name]
 	if !exists {
 		return nil, fmt.Errorf("profile '%s' not found in config. Available profiles: %v",
@@ -260,17 +380,12 @@ func (c *CLIConfig) GetActiveProfile(profileName string) (*TrinoProfileConfig, e
 
 // resolveProfileName determines the active profile name based on precedence
 func (c *CLIConfig) resolveProfileName(explicitName string) string {
-	// 1. Explicit profile name (from --profile flag or TRINO_PROFILE env)
 	if explicitName != "" {
 		return explicitName
 	}
-
-	// 2. Current field in config
 	if c.Current != "" {
 		return c.Current
 	}
-
-	// 3. "default" profile fallback
 	return "default"
 }
 
@@ -280,14 +395,7 @@ func (c *CLIConfig) getProfileNames() []string {
 	for name := range c.Profiles {
 		names = append(names, name)
 	}
-	// Simple sort (could use sort.Strings but avoiding import for now)
-	for i := 0; i < len(names); i++ {
-		for j := i + 1; j < len(names); j++ {
-			if names[i] > names[j] {
-				names[i], names[j] = names[j], names[i]
-			}
-		}
-	}
+	sort.Strings(names)
 	return names
 }
 
@@ -298,7 +406,6 @@ func (c *CLIConfig) GetProfileNames() []string {
 
 // Validate validates the config (e.g., current profile exists)
 func (c *CLIConfig) Validate() error {
-	// If current is set, ensure the profile exists
 	if c.Current != "" {
 		if _, exists := c.Profiles[c.Current]; !exists {
 			return fmt.Errorf("current profile '%s' does not exist. Available profiles: %v",
@@ -306,7 +413,6 @@ func (c *CLIConfig) Validate() error {
 		}
 	}
 
-	// Validate each profile has required fields
 	for name, profile := range c.Profiles {
 		if profile.Host == "" {
 			return fmt.Errorf("profile '%s' is missing required field 'host'", name)
@@ -342,7 +448,6 @@ func (c *CLIConfig) ApplyToEnv(profileName string) error {
 	}
 
 	setEnvIfValue("TRINO_HOST", profile.Host)
-	// Only set port if it's a valid non-zero value
 	if profile.Port > 0 {
 		setEnvIfValue("TRINO_PORT", fmt.Sprintf("%d", profile.Port))
 	}
@@ -353,10 +458,8 @@ func (c *CLIConfig) ApplyToEnv(profileName string) error {
 	if profile.Source != "" {
 		setEnvIfValue("TRINO_SOURCE", profile.Source)
 	}
-	// Only set SSL flags if explicitly configured in the YAML (non-nil pointer)
 	if profile.SSL.Enabled != nil {
 		setEnvIfValue("TRINO_SSL", fmt.Sprintf("%t", *profile.SSL.Enabled))
-		// When SSL is configured, also set INSECURE to match profile (overrides env var)
 		setEnvIfValue("TRINO_SSL_INSECURE", fmt.Sprintf("%t", profile.SSL.Insecure))
 	}
 	return nil
@@ -371,7 +474,6 @@ func (c *CLIConfig) GetOutputFormat() string {
 }
 
 // setEnvIfValue sets an environment variable to the given value (if non-empty)
-// This overrides any existing value, allowing profiles to take precedence over env vars
 func setEnvIfValue(key, value string) {
 	if value == "" {
 		return

--- a/internal/cli/config_test.go
+++ b/internal/cli/config_test.go
@@ -3,18 +3,17 @@ package cli
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
 func TestDefaultCLIConfig(t *testing.T) {
 	cfg := DefaultCLIConfig()
-
 	if cfg == nil {
 		t.Fatal("DefaultCLIConfig() returned nil")
 	}
-
 	if cfg.Output.Format != "table" {
-		t.Errorf("expected default format to be 'table', got '%s'", cfg.Output.Format)
+		t.Errorf("expected default format 'table', got '%s'", cfg.Output.Format)
 	}
 }
 
@@ -29,7 +28,6 @@ func TestParseCLIConfig_ValidJSON(t *testing.T) {
       "password": "testpass",
       "catalog": "test_catalog",
       "schema": "test_schema",
-      "source": "test_source",
       "ssl": {
         "enabled": true,
         "insecure": false
@@ -46,449 +44,7 @@ func TestParseCLIConfig_ValidJSON(t *testing.T) {
 		t.Fatalf("ParseCLIConfig() failed: %v", err)
 	}
 
-	defaultProfile, exists := cfg.Profiles["default"]
-	if !exists {
-		t.Fatal("expected 'default' profile to exist")
-	}
-
-	if defaultProfile.Host != "localhost" {
-		t.Errorf("expected host 'localhost', got '%s'", defaultProfile.Host)
-	}
-	if defaultProfile.Port != 8080 {
-		t.Errorf("expected port 8080, got %d", defaultProfile.Port)
-	}
-	if defaultProfile.User != "testuser" {
-		t.Errorf("expected user 'testuser', got '%s'", defaultProfile.User)
-	}
-	if cfg.Output.Format != "json" {
-		t.Errorf("expected output format 'json', got '%s'", cfg.Output.Format)
-	}
-
-	if defaultProfile.SSL.Enabled == nil {
-		t.Error("expected SSL.Enabled to be non-nil when explicitly set")
-	}
-	if defaultProfile.SSL.Enabled != nil && !*defaultProfile.SSL.Enabled {
-		t.Error("expected SSL.Enabled to be true")
-	}
-}
-
-func TestParseCLIConfig_InvalidJSON(t *testing.T) {
-	jsonData := []byte(`{"profiles": invalid}`)
-
-	_, err := ParseCLIConfig(jsonData)
-	if err == nil {
-		t.Error("expected error for invalid JSON, got nil")
-	}
-}
-
-func TestParseCLIConfig_EmptyJSON(t *testing.T) {
-	jsonData := []byte(``)
-
-	cfg, err := ParseCLIConfig(jsonData)
-	if err != nil {
-		t.Fatalf("ParseCLIConfig() failed: %v", err)
-	}
-
-	// Should get default profiles
-	if len(cfg.Profiles) == 0 {
-		t.Error("expected default profiles for empty config")
-	}
-}
-
-func TestGetOutputFormat(t *testing.T) {
-	tests := []struct {
-		name     string
-		format   string
-		expected string
-	}{
-		{"JSON format", "json", "json"},
-		{"Table format", "table", "table"},
-		{"CSV format", "csv", "csv"},
-		{"Empty format", "", "table"},
-		{"Unknown format", "unknown", "unknown"},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			cfg := &CLIConfig{}
-			cfg.Output.Format = tt.format
-			result := cfg.GetOutputFormat()
-			if result != tt.expected {
-				t.Errorf("GetOutputFormat() = %s, expected %s", result, tt.expected)
-			}
-		})
-	}
-}
-
-func TestApplyToEnv(t *testing.T) {
-	envVars := []string{"TRINO_HOST", "TRINO_PORT", "TRINO_USER", "TRINO_PASSWORD", "TRINO_CATALOG", "TRINO_SCHEMA", "TRINO_SSL", "TRINO_SOURCE"}
-	for _, envVar := range envVars {
-		_ = os.Unsetenv(envVar)
-	}
-
-	sslEnabled := true
-	cfg := &CLIConfig{
-		Current: "test-profile",
-		Profiles: map[string]TrinoProfileConfig{
-			"test-profile": {
-				Host:     "testhost",
-				Port:     9000,
-				User:     "testuser",
-				Password: "testpass",
-				Catalog:  "test_catalog",
-				Schema:   "test_schema",
-				Source:   "test_source",
-				SSL: SSLConfig{
-					Enabled: &sslEnabled,
-				},
-			},
-		},
-	}
-
-	_ = cfg.ApplyToEnv("test-profile")
-
-	if os.Getenv("TRINO_HOST") != "testhost" {
-		t.Errorf("expected TRINO_HOST='testhost', got '%s'", os.Getenv("TRINO_HOST"))
-	}
-	if os.Getenv("TRINO_PORT") != "9000" {
-		t.Errorf("expected TRINO_PORT='9000', got '%s'", os.Getenv("TRINO_PORT"))
-	}
-	if os.Getenv("TRINO_USER") != "testuser" {
-		t.Errorf("expected TRINO_USER='testuser', got '%s'", os.Getenv("TRINO_USER"))
-	}
-	if os.Getenv("TRINO_SOURCE") != "test_source" {
-		t.Errorf("expected TRINO_SOURCE='test_source', got '%s'", os.Getenv("TRINO_SOURCE"))
-	}
-	if os.Getenv("TRINO_SSL") != "true" {
-		t.Errorf("expected TRINO_SSL='true', got '%s'", os.Getenv("TRINO_SSL"))
-	}
-}
-
-func TestApplyToEnv_SSLDisabled(t *testing.T) {
-	_ = os.Unsetenv("TRINO_SSL")
-
-	sslEnabled := false
-	cfg := &CLIConfig{
-		Current: "test-profile",
-		Profiles: map[string]TrinoProfileConfig{
-			"test-profile": {
-				Host: "testhost",
-				SSL: SSLConfig{
-					Enabled: &sslEnabled,
-				},
-			},
-		},
-	}
-
-	_ = cfg.ApplyToEnv("test-profile")
-
-	if os.Getenv("TRINO_SSL") != "false" {
-		t.Errorf("expected TRINO_SSL='false', got '%s'", os.Getenv("TRINO_SSL"))
-	}
-}
-
-func TestApplyToEnv_SSLNotSet(t *testing.T) {
-	_ = os.Unsetenv("TRINO_SSL")
-
-	cfg := &CLIConfig{
-		Current: "test-profile",
-		Profiles: map[string]TrinoProfileConfig{
-			"test-profile": {
-				Host: "testhost",
-				SSL: SSLConfig{
-					Enabled: nil,
-				},
-			},
-		},
-	}
-
-	_ = cfg.ApplyToEnv("test-profile")
-
-	if ssl := os.Getenv("TRINO_SSL"); ssl != "" {
-		t.Errorf("expected TRINO_SSL to not be set when SSL.Enabled is nil, got '%s'", ssl)
-	}
-}
-
-func TestLoadCLIConfig_MissingFile(t *testing.T) {
-	tmpDir := t.TempDir()
-	originalHome := os.Getenv("HOME")
-	t.Cleanup(func() {
-		_ = os.Setenv("HOME", originalHome)
-	})
-
-	_ = os.Setenv("HOME", tmpDir)
-
-	cfg, err := LoadCLIConfig()
-	if err != nil {
-		t.Fatalf("LoadCLIConfig() failed: %v", err)
-	}
-
-	if cfg.Output.Format != "table" {
-		t.Errorf("expected default format 'table', got '%s'", cfg.Output.Format)
-	}
-}
-
-func TestSaveCLIConfig(t *testing.T) {
-	tmpDir := t.TempDir()
-	originalHome := os.Getenv("HOME")
-	t.Cleanup(func() {
-		_ = os.Setenv("HOME", originalHome)
-	})
-	_ = os.Setenv("HOME", tmpDir)
-
-	cfg := &CLIConfig{
-		Current: "default",
-		Profiles: map[string]TrinoProfileConfig{
-			"default": {
-				Host: "testhost",
-				Port: 8080,
-				User: "testuser",
-			},
-		},
-		Output: OutputConfig{
-			Format: "json",
-		},
-	}
-
-	err := SaveCLIConfig(cfg)
-	if err != nil {
-		t.Fatalf("SaveCLIConfig() failed: %v", err)
-	}
-
-	configPath := filepath.Join(tmpDir, ".config", "trino", "config.json")
-	if _, err := os.Stat(configPath); os.IsNotExist(err) {
-		t.Errorf("config file was not created at %s", configPath)
-	}
-
-	loadedCfg, err := LoadCLIConfig()
-	if err != nil {
-		t.Fatalf("LoadCLIConfig() failed: %v", err)
-	}
-
-	defaultProfile, exists := loadedCfg.Profiles["default"]
-	if !exists {
-		t.Fatal("default profile not found after loading")
-	}
-
-	if defaultProfile.Host != "testhost" {
-		t.Errorf("expected host 'testhost', got '%s'", defaultProfile.Host)
-	}
-	if loadedCfg.Output.Format != "json" {
-		t.Errorf("expected format 'json', got '%s'", loadedCfg.Output.Format)
-	}
-}
-
-func TestGetActiveProfile_Default(t *testing.T) {
-	cfg := &CLIConfig{
-		Current: "default",
-		Profiles: map[string]TrinoProfileConfig{
-			"default": {Host: "localhost", Port: 8080, User: "trino"},
-			"prod":    {Host: "prod.example.com", Port: 443, User: "prod_user"},
-		},
-	}
-
-	profile, err := cfg.GetActiveProfile("")
-	if err != nil {
-		t.Fatalf("GetActiveProfile() failed: %v", err)
-	}
-
-	if profile.Host != "localhost" {
-		t.Errorf("expected host 'localhost', got '%s'", profile.Host)
-	}
-}
-
-func TestGetActiveProfile_Explicit(t *testing.T) {
-	cfg := &CLIConfig{
-		Current: "default",
-		Profiles: map[string]TrinoProfileConfig{
-			"default": {Host: "localhost", Port: 8080, User: "trino"},
-			"prod":    {Host: "prod.example.com", Port: 443, User: "prod_user"},
-		},
-	}
-
-	profile, err := cfg.GetActiveProfile("prod")
-	if err != nil {
-		t.Fatalf("GetActiveProfile() failed: %v", err)
-	}
-
-	if profile.Host != "prod.example.com" {
-		t.Errorf("expected host 'prod.example.com', got '%s'", profile.Host)
-	}
-}
-
-func TestGetActiveProfile_NotFound(t *testing.T) {
-	cfg := &CLIConfig{
-		Current: "default",
-		Profiles: map[string]TrinoProfileConfig{
-			"default": {Host: "localhost", Port: 8080, User: "trino"},
-		},
-	}
-
-	_, err := cfg.GetActiveProfile("nonexistent")
-	if err == nil {
-		t.Error("GetActiveProfile() should fail for non-existent profile")
-	}
-}
-
-func TestValidate_CurrentExists(t *testing.T) {
-	cfg := &CLIConfig{
-		Current: "prod",
-		Profiles: map[string]TrinoProfileConfig{
-			"prod": {Host: "prod.example.com", Port: 443, User: "prod_user"},
-		},
-	}
-
-	if err := cfg.Validate(); err != nil {
-		t.Errorf("Validate() failed: %v", err)
-	}
-}
-
-func TestValidate_CurrentNotExists(t *testing.T) {
-	cfg := &CLIConfig{
-		Current: "nonexistent",
-		Profiles: map[string]TrinoProfileConfig{
-			"prod": {Host: "prod.example.com", Port: 443, User: "prod_user"},
-		},
-	}
-
-	if err := cfg.Validate(); err == nil {
-		t.Error("Validate() should fail when current profile doesn't exist")
-	}
-}
-
-func TestValidate_MissingRequiredFields(t *testing.T) {
-	tests := []struct {
-		name    string
-		profile TrinoProfileConfig
-	}{
-		{
-			name:    "missing host",
-			profile: TrinoProfileConfig{Port: 443, User: "testuser"},
-		},
-		{
-			name:    "invalid port",
-			profile: TrinoProfileConfig{Host: "testhost", Port: 0, User: "testuser"},
-		},
-		{
-			name:    "missing user",
-			profile: TrinoProfileConfig{Host: "testhost", Port: 443},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			cfg := &CLIConfig{
-				Current: "test",
-				Profiles: map[string]TrinoProfileConfig{
-					"test": tt.profile,
-				},
-			}
-
-			if err := cfg.Validate(); err == nil {
-				t.Error("Validate() should fail for invalid profile")
-			}
-		})
-	}
-}
-
-func TestGetProfileNames(t *testing.T) {
-	cfg := &CLIConfig{
-		Current: "prod",
-		Profiles: map[string]TrinoProfileConfig{
-			"prod":    {Host: "prod.example.com", Port: 443, User: "prod_user"},
-			"staging": {Host: "staging.example.com", Port: 443, User: "staging_user"},
-			"dev":     {Host: "localhost", Port: 8080, User: "dev_user"},
-		},
-	}
-
-	names := cfg.GetProfileNames()
-
-	if len(names) != 3 {
-		t.Errorf("expected 3 profiles, got %d", len(names))
-	}
-
-	for i := 1; i < len(names); i++ {
-		if names[i-1] > names[i] {
-			t.Errorf("profile names not sorted: %v", names)
-		}
-	}
-}
-
-func TestSetCurrent(t *testing.T) {
-	tmpDir := t.TempDir()
-	originalHome := os.Getenv("HOME")
-	t.Cleanup(func() {
-		_ = os.Setenv("HOME", originalHome)
-	})
-	_ = os.Setenv("HOME", tmpDir)
-
-	cfg := &CLIConfig{
-		Current: "default",
-		Profiles: map[string]TrinoProfileConfig{
-			"default": {Host: "localhost", Port: 8080, User: "trino"},
-			"prod":    {Host: "prod.example.com", Port: 443, User: "prod_user"},
-		},
-	}
-
-	if err := cfg.SetCurrent("prod"); err != nil {
-		t.Fatalf("SetCurrent() failed: %v", err)
-	}
-
-	if cfg.Current != "prod" {
-		t.Errorf("expected current='prod', got '%s'", cfg.Current)
-	}
-
-	loadedCfg, err := LoadCLIConfig()
-	if err != nil {
-		t.Fatalf("LoadCLIConfig() failed: %v", err)
-	}
-
-	if loadedCfg.Current != "prod" {
-		t.Errorf("expected saved current='prod', got '%s'", loadedCfg.Current)
-	}
-}
-
-func TestMigrateYAMLConfig(t *testing.T) {
-	tmpDir := t.TempDir()
-	configDir := filepath.Join(tmpDir, ".config", "trino")
-	if err := os.MkdirAll(configDir, 0755); err != nil {
-		t.Fatal(err)
-	}
-
-	yamlData := []byte(`current: default
-profiles:
-  default:
-    host: localhost
-    port: 8080
-    user: testuser
-    password: testpass
-    catalog: test_catalog
-    schema: test_schema
-    ssl:
-      enabled: true
-      insecure: false
-output:
-  format: json
-`)
-	yamlPath := filepath.Join(configDir, "config.yaml")
-	jsonPath := filepath.Join(configDir, "config.json")
-
-	if err := os.WriteFile(yamlPath, yamlData, 0600); err != nil {
-		t.Fatal(err)
-	}
-
-	cfg, err := migrateYAMLConfig(yamlPath, jsonPath)
-	if err != nil {
-		t.Fatalf("migrateYAMLConfig() failed: %v", err)
-	}
-
-	if cfg.Current != "default" {
-		t.Errorf("expected current 'default', got '%s'", cfg.Current)
-	}
-	p, exists := cfg.Profiles["default"]
-	if !exists {
-		t.Fatal("expected 'default' profile")
-	}
+	p := cfg.Profiles["default"]
 	if p.Host != "localhost" {
 		t.Errorf("expected host 'localhost', got '%s'", p.Host)
 	}
@@ -502,44 +58,111 @@ output:
 		t.Errorf("expected format 'json', got '%s'", cfg.Output.Format)
 	}
 	if p.SSL.Enabled == nil || !*p.SSL.Enabled {
-		t.Error("expected SSL enabled true")
-	}
-
-	// Verify JSON file was created
-	if _, err := os.Stat(jsonPath); os.IsNotExist(err) {
-		t.Error("JSON config file was not created")
+		t.Error("expected SSL.Enabled to be true")
 	}
 }
 
-func TestMigrateYAMLConfig_LegacyFlat(t *testing.T) {
-	tmpDir := t.TempDir()
-	configDir := filepath.Join(tmpDir, ".config", "trino")
-	if err := os.MkdirAll(configDir, 0755); err != nil {
-		t.Fatal(err)
+func TestParseCLIConfig_InvalidJSON(t *testing.T) {
+	_, err := ParseCLIConfig([]byte(`{"profiles": invalid}`))
+	if err == nil {
+		t.Error("expected error for invalid JSON, got nil")
+	}
+}
+
+func TestParseCLIConfig_EmptyJSON(t *testing.T) {
+	cfg, err := ParseCLIConfig([]byte(``))
+	if err != nil {
+		t.Fatalf("ParseCLIConfig() failed: %v", err)
+	}
+	if len(cfg.Profiles) == 0 {
+		t.Error("expected default profiles for empty config")
+	}
+}
+
+func TestParseYAMLConfig(t *testing.T) {
+	yamlData := []byte(`current: default
+profiles:
+  default:
+    host: localhost
+    port: 8080
+    user: testuser
+    password: testpass
+    catalog: test_catalog
+    schema: test_schema
+    source: test_source
+    ssl:
+      enabled: true
+      insecure: false
+  prod:
+    host: prod.example.com
+    port: 443
+    user: prod_user
+    ssl:
+      enabled: true
+output:
+  format: csv
+`)
+
+	cfg, err := ParseCLIConfigWithPath(yamlData, "/tmp/config.yaml")
+	if err != nil {
+		t.Fatalf("ParseCLIConfigWithPath(yaml) failed: %v", err)
 	}
 
+	if cfg.Current != "default" {
+		t.Errorf("expected current 'default', got '%s'", cfg.Current)
+	}
+
+	p := cfg.Profiles["default"]
+	if p.Host != "localhost" {
+		t.Errorf("expected host 'localhost', got '%s'", p.Host)
+	}
+	if p.Port != 8080 {
+		t.Errorf("expected port 8080, got %d", p.Port)
+	}
+	if p.User != "testuser" {
+		t.Errorf("expected user 'testuser', got '%s'", p.User)
+	}
+	if p.Password != "testpass" {
+		t.Errorf("expected password 'testpass', got '%s'", p.Password)
+	}
+	if p.Source != "test_source" {
+		t.Errorf("expected source 'test_source', got '%s'", p.Source)
+	}
+	if p.SSL.Enabled == nil || !*p.SSL.Enabled {
+		t.Error("expected SSL enabled true")
+	}
+
+	prod := cfg.Profiles["prod"]
+	if prod.Host != "prod.example.com" {
+		t.Errorf("expected prod host 'prod.example.com', got '%s'", prod.Host)
+	}
+
+	if cfg.Output.Format != "csv" {
+		t.Errorf("expected format 'csv', got '%s'", cfg.Output.Format)
+	}
+}
+
+func TestParseYAMLConfig_LegacyFlat(t *testing.T) {
 	yamlData := []byte(`trino:
   host: legacy-host
   port: 9090
   user: legacy-user
+  catalog: mycatalog
+  ssl:
+    enabled: true
+    insecure: true
 output:
   format: csv
 `)
-	yamlPath := filepath.Join(configDir, "config.yaml")
-	jsonPath := filepath.Join(configDir, "config.json")
 
-	if err := os.WriteFile(yamlPath, yamlData, 0600); err != nil {
-		t.Fatal(err)
-	}
-
-	cfg, err := migrateYAMLConfig(yamlPath, jsonPath)
+	cfg, err := ParseCLIConfigWithPath(yamlData, "/tmp/config.yaml")
 	if err != nil {
-		t.Fatalf("migrateYAMLConfig() failed: %v", err)
+		t.Fatalf("ParseCLIConfigWithPath(yaml legacy) failed: %v", err)
 	}
 
 	p, exists := cfg.Profiles["default"]
 	if !exists {
-		t.Fatal("expected 'default' profile from legacy migration")
+		t.Fatal("expected 'default' profile from legacy flat migration")
 	}
 	if p.Host != "legacy-host" {
 		t.Errorf("expected host 'legacy-host', got '%s'", p.Host)
@@ -547,60 +170,28 @@ output:
 	if p.Port != 9090 {
 		t.Errorf("expected port 9090, got %d", p.Port)
 	}
-}
-
-func TestLoadCLIConfig_FallbackToYAML(t *testing.T) {
-	tmpDir := t.TempDir()
-	originalHome := os.Getenv("HOME")
-	t.Cleanup(func() {
-		_ = os.Setenv("HOME", originalHome)
-	})
-	_ = os.Setenv("HOME", tmpDir)
-
-	configDir := filepath.Join(tmpDir, ".config", "trino")
-	if err := os.MkdirAll(configDir, 0755); err != nil {
-		t.Fatal(err)
+	if p.Catalog != "mycatalog" {
+		t.Errorf("expected catalog 'mycatalog', got '%s'", p.Catalog)
 	}
-
-	yamlData := []byte(`current: default
-profiles:
-  default:
-    host: yaml-host
-    port: 7070
-    user: yaml-user
-`)
-	if err := os.WriteFile(filepath.Join(configDir, "config.yaml"), yamlData, 0600); err != nil {
-		t.Fatal(err)
+	if p.SSL.Enabled == nil || !*p.SSL.Enabled {
+		t.Error("expected SSL enabled true")
 	}
-
-	cfg, err := LoadCLIConfig()
-	if err != nil {
-		t.Fatalf("LoadCLIConfig() failed: %v", err)
+	if !p.SSL.Insecure {
+		t.Error("expected SSL insecure true")
 	}
-
-	p, exists := cfg.Profiles["default"]
-	if !exists {
-		t.Fatal("expected 'default' profile from YAML fallback")
-	}
-	if p.Host != "yaml-host" {
-		t.Errorf("expected host 'yaml-host', got '%s'", p.Host)
-	}
-
-	// Verify JSON was created (migration happened)
-	jsonPath := filepath.Join(configDir, "config.json")
-	if _, err := os.Stat(jsonPath); os.IsNotExist(err) {
-		t.Error("JSON config was not created during migration")
+	if cfg.Output.Format != "csv" {
+		t.Errorf("expected format 'csv', got '%s'", cfg.Output.Format)
 	}
 }
 
-func TestMigrateYAMLConfig_FieldsAfterSSL(t *testing.T) {
-	tmpDir := t.TempDir()
-	configDir := filepath.Join(tmpDir, ".config", "trino")
-	if err := os.MkdirAll(configDir, 0755); err != nil {
-		t.Fatal(err)
+func TestParseYAMLConfig_Invalid(t *testing.T) {
+	_, err := ParseCLIConfigWithPath([]byte(`{invalid: yaml: [`), "/tmp/config.yaml")
+	if err == nil {
+		t.Error("expected error for invalid YAML, got nil")
 	}
+}
 
-	// Fields after ssl block must be parsed correctly
+func TestParseYAMLConfig_FieldsAfterSSL(t *testing.T) {
 	yamlData := []byte(`trino:
   host: myhost
   ssl:
@@ -609,42 +200,374 @@ func TestMigrateYAMLConfig_FieldsAfterSSL(t *testing.T) {
   user: afterssl
   catalog: mycat
 `)
-	yamlPath := filepath.Join(configDir, "config.yaml")
-	jsonPath := filepath.Join(configDir, "config.json")
 
-	if err := os.WriteFile(yamlPath, yamlData, 0600); err != nil {
-		t.Fatal(err)
-	}
-
-	cfg, err := migrateYAMLConfig(yamlPath, jsonPath)
+	cfg, err := ParseCLIConfigWithPath(yamlData, "/tmp/config.yaml")
 	if err != nil {
-		t.Fatalf("migrateYAMLConfig() failed: %v", err)
+		t.Fatalf("failed: %v", err)
 	}
 
 	p := cfg.Profiles["default"]
 	if p.User != "afterssl" {
-		t.Errorf("expected user 'afterssl' (after ssl block), got '%s'", p.User)
+		t.Errorf("expected user 'afterssl', got '%s'", p.User)
 	}
 	if p.Catalog != "mycat" {
-		t.Errorf("expected catalog 'mycat' (after ssl block), got '%s'", p.Catalog)
+		t.Errorf("expected catalog 'mycat', got '%s'", p.Catalog)
 	}
 	if p.SSL.Enabled == nil || !*p.SSL.Enabled {
 		t.Error("expected SSL enabled true")
 	}
-	if !p.SSL.Insecure {
-		t.Error("expected SSL insecure true")
+}
+
+func TestGetOutputFormat(t *testing.T) {
+	tests := []struct {
+		name, format, expected string
+	}{
+		{"JSON format", "json", "json"},
+		{"Table format", "table", "table"},
+		{"CSV format", "csv", "csv"},
+		{"Empty format", "", "table"},
+		{"Unknown format", "unknown", "unknown"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &CLIConfig{}
+			cfg.Output.Format = tt.format
+			if result := cfg.GetOutputFormat(); result != tt.expected {
+				t.Errorf("GetOutputFormat() = %s, expected %s", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestApplyToEnv(t *testing.T) {
+	for _, v := range []string{"TRINO_HOST", "TRINO_PORT", "TRINO_USER", "TRINO_PASSWORD", "TRINO_CATALOG", "TRINO_SCHEMA", "TRINO_SSL", "TRINO_SOURCE"} {
+		_ = os.Unsetenv(v)
+	}
+
+	sslEnabled := true
+	cfg := &CLIConfig{
+		Current: "test-profile",
+		Profiles: map[string]TrinoProfileConfig{
+			"test-profile": {
+				Host: "testhost", Port: 9000, User: "testuser",
+				Password: "testpass", Catalog: "test_catalog", Schema: "test_schema",
+				Source: "test_source", SSL: SSLConfig{Enabled: &sslEnabled},
+			},
+		},
+	}
+
+	_ = cfg.ApplyToEnv("test-profile")
+
+	checks := map[string]string{
+		"TRINO_HOST": "testhost", "TRINO_PORT": "9000", "TRINO_USER": "testuser",
+		"TRINO_SOURCE": "test_source", "TRINO_SSL": "true",
+	}
+	for k, want := range checks {
+		if got := os.Getenv(k); got != want {
+			t.Errorf("expected %s='%s', got '%s'", k, want, got)
+		}
+	}
+}
+
+func TestApplyToEnv_SSLDisabled(t *testing.T) {
+	_ = os.Unsetenv("TRINO_SSL")
+	sslEnabled := false
+	cfg := &CLIConfig{
+		Current:  "p",
+		Profiles: map[string]TrinoProfileConfig{"p": {Host: "h", SSL: SSLConfig{Enabled: &sslEnabled}}},
+	}
+	_ = cfg.ApplyToEnv("p")
+	if os.Getenv("TRINO_SSL") != "false" {
+		t.Errorf("expected TRINO_SSL='false', got '%s'", os.Getenv("TRINO_SSL"))
+	}
+}
+
+func TestApplyToEnv_SSLNotSet(t *testing.T) {
+	_ = os.Unsetenv("TRINO_SSL")
+	cfg := &CLIConfig{
+		Current:  "p",
+		Profiles: map[string]TrinoProfileConfig{"p": {Host: "h", SSL: SSLConfig{Enabled: nil}}},
+	}
+	_ = cfg.ApplyToEnv("p")
+	if ssl := os.Getenv("TRINO_SSL"); ssl != "" {
+		t.Errorf("expected TRINO_SSL unset, got '%s'", ssl)
+	}
+}
+
+func TestLoadCLIConfig_MissingFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	orig := os.Getenv("HOME")
+	t.Cleanup(func() { _ = os.Setenv("HOME", orig) })
+	_ = os.Setenv("HOME", tmpDir)
+
+	cfg, err := LoadCLIConfig()
+	if err != nil {
+		t.Fatalf("LoadCLIConfig() failed: %v", err)
+	}
+	if cfg.Output.Format != "table" {
+		t.Errorf("expected default format 'table', got '%s'", cfg.Output.Format)
+	}
+}
+
+func TestLoadCLIConfig_JSONFirst(t *testing.T) {
+	tmpDir := t.TempDir()
+	orig := os.Getenv("HOME")
+	t.Cleanup(func() { _ = os.Setenv("HOME", orig) })
+	_ = os.Setenv("HOME", tmpDir)
+
+	configDir := filepath.Join(tmpDir, ".config", "trino")
+	_ = os.MkdirAll(configDir, 0755)
+
+	// Write both JSON and YAML — JSON should win
+	_ = os.WriteFile(filepath.Join(configDir, "config.json"), []byte(`{"current":"json-profile","profiles":{"json-profile":{"host":"json-host","port":8080,"user":"u"}}}`), 0600)
+	_ = os.WriteFile(filepath.Join(configDir, "config.yaml"), []byte("current: yaml-profile\nprofiles:\n  yaml-profile:\n    host: yaml-host\n    port: 8080\n    user: u\n"), 0600)
+
+	cfg, err := LoadCLIConfig()
+	if err != nil {
+		t.Fatalf("LoadCLIConfig() failed: %v", err)
+	}
+	if cfg.Current != "json-profile" {
+		t.Errorf("expected JSON to take precedence, got current='%s'", cfg.Current)
+	}
+}
+
+func TestLoadCLIConfig_YAMLFallback(t *testing.T) {
+	tmpDir := t.TempDir()
+	orig := os.Getenv("HOME")
+	t.Cleanup(func() { _ = os.Setenv("HOME", orig) })
+	_ = os.Setenv("HOME", tmpDir)
+
+	configDir := filepath.Join(tmpDir, ".config", "trino")
+	_ = os.MkdirAll(configDir, 0755)
+
+	_ = os.WriteFile(filepath.Join(configDir, "config.yaml"), []byte("current: default\nprofiles:\n  default:\n    host: yaml-host\n    port: 7070\n    user: yaml-user\n"), 0600)
+
+	cfg, err := LoadCLIConfig()
+	if err != nil {
+		t.Fatalf("LoadCLIConfig() failed: %v", err)
+	}
+	if cfg.Profiles["default"].Host != "yaml-host" {
+		t.Errorf("expected host 'yaml-host', got '%s'", cfg.Profiles["default"].Host)
+	}
+	// ConfigPath should be the YAML file (no forced migration)
+	if !strings.HasSuffix(cfg.ConfigPath, "config.yaml") {
+		t.Errorf("expected ConfigPath to be yaml, got '%s'", cfg.ConfigPath)
+	}
+}
+
+func TestSaveCLIConfig_JSON(t *testing.T) {
+	tmpDir := t.TempDir()
+	orig := os.Getenv("HOME")
+	t.Cleanup(func() { _ = os.Setenv("HOME", orig) })
+	_ = os.Setenv("HOME", tmpDir)
+
+	cfg := &CLIConfig{
+		Current:  "default",
+		Profiles: map[string]TrinoProfileConfig{"default": {Host: "testhost", Port: 8080, User: "testuser"}},
+		Output:   OutputConfig{Format: "json"},
+	}
+
+	if err := SaveCLIConfig(cfg); err != nil {
+		t.Fatalf("SaveCLIConfig() failed: %v", err)
+	}
+
+	configPath := filepath.Join(tmpDir, ".config", "trino", "config.json")
+	if _, err := os.Stat(configPath); os.IsNotExist(err) {
+		t.Errorf("config file not created at %s", configPath)
+	}
+
+	loaded, err := LoadCLIConfig()
+	if err != nil {
+		t.Fatalf("LoadCLIConfig() failed: %v", err)
+	}
+	if loaded.Profiles["default"].Host != "testhost" {
+		t.Errorf("expected host 'testhost', got '%s'", loaded.Profiles["default"].Host)
+	}
+}
+
+func TestSaveCLIConfig_YAML(t *testing.T) {
+	tmpDir := t.TempDir()
+	yamlPath := filepath.Join(tmpDir, "config.yaml")
+
+	cfg := &CLIConfig{
+		ConfigPath: yamlPath,
+		Current:    "default",
+		Profiles:   map[string]TrinoProfileConfig{"default": {Host: "yamlhost", Port: 443, User: "yuser"}},
+		Output:     OutputConfig{Format: "table"},
+	}
+
+	if err := SaveCLIConfig(cfg); err != nil {
+		t.Fatalf("SaveCLIConfig(yaml) failed: %v", err)
+	}
+
+	data, err := os.ReadFile(yamlPath)
+	if err != nil {
+		t.Fatalf("failed to read saved yaml: %v", err)
+	}
+	if !strings.Contains(string(data), "yamlhost") {
+		t.Errorf("expected YAML to contain 'yamlhost', got: %s", string(data))
+	}
+
+	// Verify we can load it back
+	loaded, err := ParseCLIConfigWithPath(data, yamlPath)
+	if err != nil {
+		t.Fatalf("failed to parse saved yaml: %v", err)
+	}
+	if loaded.Profiles["default"].Host != "yamlhost" {
+		t.Errorf("roundtrip failed: expected 'yamlhost', got '%s'", loaded.Profiles["default"].Host)
+	}
+}
+
+func TestGetActiveProfile_Default(t *testing.T) {
+	cfg := &CLIConfig{
+		Current: "default",
+		Profiles: map[string]TrinoProfileConfig{
+			"default": {Host: "localhost", Port: 8080, User: "trino"},
+			"prod":    {Host: "prod.example.com", Port: 443, User: "prod_user"},
+		},
+	}
+	profile, err := cfg.GetActiveProfile("")
+	if err != nil {
+		t.Fatalf("GetActiveProfile() failed: %v", err)
+	}
+	if profile.Host != "localhost" {
+		t.Errorf("expected 'localhost', got '%s'", profile.Host)
+	}
+}
+
+func TestGetActiveProfile_Explicit(t *testing.T) {
+	cfg := &CLIConfig{
+		Current: "default",
+		Profiles: map[string]TrinoProfileConfig{
+			"default": {Host: "localhost", Port: 8080, User: "trino"},
+			"prod":    {Host: "prod.example.com", Port: 443, User: "prod_user"},
+		},
+	}
+	profile, err := cfg.GetActiveProfile("prod")
+	if err != nil {
+		t.Fatalf("GetActiveProfile() failed: %v", err)
+	}
+	if profile.Host != "prod.example.com" {
+		t.Errorf("expected 'prod.example.com', got '%s'", profile.Host)
+	}
+}
+
+func TestGetActiveProfile_NotFound(t *testing.T) {
+	cfg := &CLIConfig{
+		Current:  "default",
+		Profiles: map[string]TrinoProfileConfig{"default": {Host: "localhost", Port: 8080, User: "trino"}},
+	}
+	if _, err := cfg.GetActiveProfile("nonexistent"); err == nil {
+		t.Error("should fail for non-existent profile")
+	}
+}
+
+func TestValidate(t *testing.T) {
+	// Valid
+	cfg := &CLIConfig{Current: "p", Profiles: map[string]TrinoProfileConfig{"p": {Host: "h", Port: 443, User: "u"}}}
+	if err := cfg.Validate(); err != nil {
+		t.Errorf("Validate() failed: %v", err)
+	}
+
+	// Invalid current
+	cfg2 := &CLIConfig{Current: "missing", Profiles: map[string]TrinoProfileConfig{"p": {Host: "h", Port: 443, User: "u"}}}
+	if err := cfg2.Validate(); err == nil {
+		t.Error("should fail when current doesn't exist")
+	}
+
+	// Missing fields
+	for _, tc := range []struct {
+		name string
+		p    TrinoProfileConfig
+	}{
+		{"missing host", TrinoProfileConfig{Port: 443, User: "u"}},
+		{"invalid port", TrinoProfileConfig{Host: "h", Port: 0, User: "u"}},
+		{"missing user", TrinoProfileConfig{Host: "h", Port: 443}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			c := &CLIConfig{Current: "t", Profiles: map[string]TrinoProfileConfig{"t": tc.p}}
+			if err := c.Validate(); err == nil {
+				t.Error("should fail")
+			}
+		})
+	}
+}
+
+func TestGetProfileNames(t *testing.T) {
+	cfg := &CLIConfig{
+		Profiles: map[string]TrinoProfileConfig{
+			"prod": {}, "staging": {}, "dev": {},
+		},
+	}
+	names := cfg.GetProfileNames()
+	if len(names) != 3 {
+		t.Errorf("expected 3 profiles, got %d", len(names))
+	}
+	for i := 1; i < len(names); i++ {
+		if names[i-1] > names[i] {
+			t.Errorf("not sorted: %v", names)
+		}
+	}
+}
+
+func TestSetCurrent(t *testing.T) {
+	tmpDir := t.TempDir()
+	orig := os.Getenv("HOME")
+	t.Cleanup(func() { _ = os.Setenv("HOME", orig) })
+	_ = os.Setenv("HOME", tmpDir)
+
+	cfg := &CLIConfig{
+		Current: "default",
+		Profiles: map[string]TrinoProfileConfig{
+			"default": {Host: "localhost", Port: 8080, User: "trino"},
+			"prod":    {Host: "prod.example.com", Port: 443, User: "prod_user"},
+		},
+	}
+	if err := cfg.SetCurrent("prod"); err != nil {
+		t.Fatalf("SetCurrent() failed: %v", err)
+	}
+	if cfg.Current != "prod" {
+		t.Errorf("expected current='prod', got '%s'", cfg.Current)
+	}
+
+	loaded, err := LoadCLIConfig()
+	if err != nil {
+		t.Fatalf("LoadCLIConfig() failed: %v", err)
+	}
+	if loaded.Current != "prod" {
+		t.Errorf("expected saved current='prod', got '%s'", loaded.Current)
+	}
+}
+
+func TestSaveCLIConfig_YAML_NoTrinoLeak(t *testing.T) {
+	tmpDir := t.TempDir()
+	yamlPath := filepath.Join(tmpDir, "config.yaml")
+
+	// Simulate a config that was loaded from legacy flat YAML (Trino field set)
+	cfg := &CLIConfig{
+		ConfigPath: yamlPath,
+		Current:    "default",
+		Profiles:   map[string]TrinoProfileConfig{"default": {Host: "h", Port: 80, User: "u"}},
+		Trino:      &TrinoProfileConfig{Host: "leaked"},
+	}
+
+	if err := SaveCLIConfig(cfg); err != nil {
+		t.Fatalf("SaveCLIConfig() failed: %v", err)
+	}
+
+	data, _ := os.ReadFile(yamlPath)
+	if strings.Contains(string(data), "leaked") {
+		t.Errorf("saved YAML should not contain legacy Trino field, got:\n%s", string(data))
 	}
 }
 
 func TestSetCurrent_NotFound(t *testing.T) {
 	cfg := &CLIConfig{
-		Current: "default",
-		Profiles: map[string]TrinoProfileConfig{
-			"default": {Host: "localhost", Port: 8080, User: "trino"},
-		},
+		Current:  "default",
+		Profiles: map[string]TrinoProfileConfig{"default": {Host: "localhost", Port: 8080, User: "trino"}},
 	}
-
 	if err := cfg.SetCurrent("nonexistent"); err == nil {
-		t.Error("SetCurrent() should fail for non-existent profile")
+		t.Error("should fail for non-existent profile")
 	}
 }

--- a/internal/cli/config_test.go
+++ b/internal/cli/config_test.go
@@ -18,32 +18,37 @@ func TestDefaultCLIConfig(t *testing.T) {
 	}
 }
 
-func TestParseCLIConfig_ValidYAML(t *testing.T) {
-	yamlData := []byte(`
-trino:
-  host: localhost
-  port: 8080
-  user: testuser
-  password: testpass
-  catalog: test_catalog
-  schema: test_schema
-  source: test_source
-  ssl:
-    enabled: true
-    insecure: false
-output:
-  format: json
-`)
+func TestParseCLIConfig_ValidJSON(t *testing.T) {
+	jsonData := []byte(`{
+  "current": "default",
+  "profiles": {
+    "default": {
+      "host": "localhost",
+      "port": 8080,
+      "user": "testuser",
+      "password": "testpass",
+      "catalog": "test_catalog",
+      "schema": "test_schema",
+      "source": "test_source",
+      "ssl": {
+        "enabled": true,
+        "insecure": false
+      }
+    }
+  },
+  "output": {
+    "format": "json"
+  }
+}`)
 
-	cfg, err := ParseCLIConfig(yamlData)
+	cfg, err := ParseCLIConfig(jsonData)
 	if err != nil {
 		t.Fatalf("ParseCLIConfig() failed: %v", err)
 	}
 
-	// After migration, data should be in Profiles["default"]
 	defaultProfile, exists := cfg.Profiles["default"]
 	if !exists {
-		t.Fatal("expected 'default' profile to exist after migration")
+		t.Fatal("expected 'default' profile to exist")
 	}
 
 	if defaultProfile.Host != "localhost" {
@@ -59,39 +64,34 @@ output:
 		t.Errorf("expected output format 'json', got '%s'", cfg.Output.Format)
 	}
 
-	// Test SSL pointer bool
 	if defaultProfile.SSL.Enabled == nil {
 		t.Error("expected SSL.Enabled to be non-nil when explicitly set")
 	}
 	if defaultProfile.SSL.Enabled != nil && !*defaultProfile.SSL.Enabled {
 		t.Error("expected SSL.Enabled to be true")
 	}
-
-	// Verify current is set to "default" after migration
-	if cfg.Current != "default" {
-		t.Errorf("expected current to be 'default' after migration, got '%s'", cfg.Current)
-	}
 }
 
-func TestParseCLIConfig_InvalidYAML(t *testing.T) {
-	yamlData := []byte(`trino: host: [invalid`)
+func TestParseCLIConfig_InvalidJSON(t *testing.T) {
+	jsonData := []byte(`{"profiles": invalid}`)
 
-	_, err := ParseCLIConfig(yamlData)
+	_, err := ParseCLIConfig(jsonData)
 	if err == nil {
-		t.Error("expected error for invalid YAML, got nil")
+		t.Error("expected error for invalid JSON, got nil")
 	}
 }
 
-func TestParseCLIConfig_EmptyYAML(t *testing.T) {
-	yamlData := []byte(``)
+func TestParseCLIConfig_EmptyJSON(t *testing.T) {
+	jsonData := []byte(``)
 
-	cfg, err := ParseCLIConfig(yamlData)
+	cfg, err := ParseCLIConfig(jsonData)
 	if err != nil {
 		t.Fatalf("ParseCLIConfig() failed: %v", err)
 	}
 
-	if cfg.Output.Format != "" {
-		t.Errorf("expected empty format for empty YAML, got '%s'", cfg.Output.Format)
+	// Should get default profiles
+	if len(cfg.Profiles) == 0 {
+		t.Error("expected default profiles for empty config")
 	}
 }
 
@@ -121,7 +121,6 @@ func TestGetOutputFormat(t *testing.T) {
 }
 
 func TestApplyToEnv(t *testing.T) {
-	// Clean environment before test
 	envVars := []string{"TRINO_HOST", "TRINO_PORT", "TRINO_USER", "TRINO_PASSWORD", "TRINO_CATALOG", "TRINO_SCHEMA", "TRINO_SSL", "TRINO_SOURCE"}
 	for _, envVar := range envVars {
 		_ = os.Unsetenv(envVar)
@@ -139,10 +138,7 @@ func TestApplyToEnv(t *testing.T) {
 				Catalog:  "test_catalog",
 				Schema:   "test_schema",
 				Source:   "test_source",
-				SSL: struct {
-					Enabled  *bool `yaml:"enabled"`
-					Insecure bool  `yaml:"insecure"`
-				}{
+				SSL: SSLConfig{
 					Enabled: &sslEnabled,
 				},
 			},
@@ -151,7 +147,6 @@ func TestApplyToEnv(t *testing.T) {
 
 	_ = cfg.ApplyToEnv("test-profile")
 
-	// Verify environment variables were set
 	if os.Getenv("TRINO_HOST") != "testhost" {
 		t.Errorf("expected TRINO_HOST='testhost', got '%s'", os.Getenv("TRINO_HOST"))
 	}
@@ -170,7 +165,6 @@ func TestApplyToEnv(t *testing.T) {
 }
 
 func TestApplyToEnv_SSLDisabled(t *testing.T) {
-	// Clean environment before test
 	_ = os.Unsetenv("TRINO_SSL")
 
 	sslEnabled := false
@@ -179,10 +173,7 @@ func TestApplyToEnv_SSLDisabled(t *testing.T) {
 		Profiles: map[string]TrinoProfileConfig{
 			"test-profile": {
 				Host: "testhost",
-				SSL: struct {
-					Enabled  *bool `yaml:"enabled"`
-					Insecure bool  `yaml:"insecure"`
-				}{
+				SSL: SSLConfig{
 					Enabled: &sslEnabled,
 				},
 			},
@@ -191,14 +182,12 @@ func TestApplyToEnv_SSLDisabled(t *testing.T) {
 
 	_ = cfg.ApplyToEnv("test-profile")
 
-	// Verify TRINO_SSL is set to false
 	if os.Getenv("TRINO_SSL") != "false" {
 		t.Errorf("expected TRINO_SSL='false', got '%s'", os.Getenv("TRINO_SSL"))
 	}
 }
 
 func TestApplyToEnv_SSLNotSet(t *testing.T) {
-	// Clean environment before test
 	_ = os.Unsetenv("TRINO_SSL")
 
 	cfg := &CLIConfig{
@@ -206,34 +195,27 @@ func TestApplyToEnv_SSLNotSet(t *testing.T) {
 		Profiles: map[string]TrinoProfileConfig{
 			"test-profile": {
 				Host: "testhost",
-				SSL: struct {
-					Enabled  *bool `yaml:"enabled"`
-					Insecure bool  `yaml:"insecure"`
-				}{
-					Enabled: nil, // not set
+				SSL: SSLConfig{
+					Enabled: nil,
 				},
 			},
 		},
 	}
 
-	// SSL.Enabled is nil (not set in config)
 	_ = cfg.ApplyToEnv("test-profile")
 
-	// Verify TRINO_SSL is NOT set (preserves default)
 	if ssl := os.Getenv("TRINO_SSL"); ssl != "" {
 		t.Errorf("expected TRINO_SSL to not be set when SSL.Enabled is nil, got '%s'", ssl)
 	}
 }
 
 func TestLoadCLIConfig_MissingFile(t *testing.T) {
-	// Use a temp directory to ensure config doesn't exist
 	tmpDir := t.TempDir()
 	originalHome := os.Getenv("HOME")
 	t.Cleanup(func() {
 		_ = os.Setenv("HOME", originalHome)
 	})
 
-	// Set HOME to temp dir (where no .config/trino/config.yaml exists)
 	_ = os.Setenv("HOME", tmpDir)
 
 	cfg, err := LoadCLIConfig()
@@ -241,7 +223,6 @@ func TestLoadCLIConfig_MissingFile(t *testing.T) {
 		t.Fatalf("LoadCLIConfig() failed: %v", err)
 	}
 
-	// Should return default config
 	if cfg.Output.Format != "table" {
 		t.Errorf("expected default format 'table', got '%s'", cfg.Output.Format)
 	}
@@ -264,9 +245,7 @@ func TestSaveCLIConfig(t *testing.T) {
 				User: "testuser",
 			},
 		},
-		Output: struct {
-			Format string `yaml:"format"`
-		}{
+		Output: OutputConfig{
 			Format: "json",
 		},
 	}
@@ -276,19 +255,16 @@ func TestSaveCLIConfig(t *testing.T) {
 		t.Fatalf("SaveCLIConfig() failed: %v", err)
 	}
 
-	// Verify file was created
-	configPath := filepath.Join(tmpDir, ".config", "trino", "config.yaml")
+	configPath := filepath.Join(tmpDir, ".config", "trino", "config.json")
 	if _, err := os.Stat(configPath); os.IsNotExist(err) {
 		t.Errorf("config file was not created at %s", configPath)
 	}
 
-	// Verify we can load it back
 	loadedCfg, err := LoadCLIConfig()
 	if err != nil {
 		t.Fatalf("LoadCLIConfig() failed: %v", err)
 	}
 
-	// Check the default profile was loaded
 	defaultProfile, exists := loadedCfg.Profiles["default"]
 	if !exists {
 		t.Fatal("default profile not found after loading")
@@ -302,22 +278,12 @@ func TestSaveCLIConfig(t *testing.T) {
 	}
 }
 
-// Profile-related tests
-
 func TestGetActiveProfile_Default(t *testing.T) {
 	cfg := &CLIConfig{
 		Current: "default",
 		Profiles: map[string]TrinoProfileConfig{
-			"default": {
-				Host: "localhost",
-				Port: 8080,
-				User: "trino",
-			},
-			"prod": {
-				Host: "prod.example.com",
-				Port: 443,
-				User: "prod_user",
-			},
+			"default": {Host: "localhost", Port: 8080, User: "trino"},
+			"prod":    {Host: "prod.example.com", Port: 443, User: "prod_user"},
 		},
 	}
 
@@ -335,16 +301,8 @@ func TestGetActiveProfile_Explicit(t *testing.T) {
 	cfg := &CLIConfig{
 		Current: "default",
 		Profiles: map[string]TrinoProfileConfig{
-			"default": {
-				Host: "localhost",
-				Port: 8080,
-				User: "trino",
-			},
-			"prod": {
-				Host: "prod.example.com",
-				Port: 443,
-				User: "prod_user",
-			},
+			"default": {Host: "localhost", Port: 8080, User: "trino"},
+			"prod":    {Host: "prod.example.com", Port: 443, User: "prod_user"},
 		},
 	}
 
@@ -362,11 +320,7 @@ func TestGetActiveProfile_NotFound(t *testing.T) {
 	cfg := &CLIConfig{
 		Current: "default",
 		Profiles: map[string]TrinoProfileConfig{
-			"default": {
-				Host: "localhost",
-				Port: 8080,
-				User: "trino",
-			},
+			"default": {Host: "localhost", Port: 8080, User: "trino"},
 		},
 	}
 
@@ -380,11 +334,7 @@ func TestValidate_CurrentExists(t *testing.T) {
 	cfg := &CLIConfig{
 		Current: "prod",
 		Profiles: map[string]TrinoProfileConfig{
-			"prod": {
-				Host: "prod.example.com",
-				Port: 443,
-				User: "prod_user",
-			},
+			"prod": {Host: "prod.example.com", Port: 443, User: "prod_user"},
 		},
 	}
 
@@ -397,11 +347,7 @@ func TestValidate_CurrentNotExists(t *testing.T) {
 	cfg := &CLIConfig{
 		Current: "nonexistent",
 		Profiles: map[string]TrinoProfileConfig{
-			"prod": {
-				Host: "prod.example.com",
-				Port: 443,
-				User: "prod_user",
-			},
+			"prod": {Host: "prod.example.com", Port: 443, User: "prod_user"},
 		},
 	}
 
@@ -416,26 +362,16 @@ func TestValidate_MissingRequiredFields(t *testing.T) {
 		profile TrinoProfileConfig
 	}{
 		{
-			name: "missing host",
-			profile: TrinoProfileConfig{
-				Port: 443,
-				User: "testuser",
-			},
+			name:    "missing host",
+			profile: TrinoProfileConfig{Port: 443, User: "testuser"},
 		},
 		{
-			name: "invalid port",
-			profile: TrinoProfileConfig{
-				Host: "testhost",
-				Port: 0,
-				User: "testuser",
-			},
+			name:    "invalid port",
+			profile: TrinoProfileConfig{Host: "testhost", Port: 0, User: "testuser"},
 		},
 		{
-			name: "missing user",
-			profile: TrinoProfileConfig{
-				Host: "testhost",
-				Port: 443,
-			},
+			name:    "missing user",
+			profile: TrinoProfileConfig{Host: "testhost", Port: 443},
 		},
 	}
 
@@ -471,7 +407,6 @@ func TestGetProfileNames(t *testing.T) {
 		t.Errorf("expected 3 profiles, got %d", len(names))
 	}
 
-	// Check that names are sorted
 	for i := 1; i < len(names); i++ {
 		if names[i-1] > names[i] {
 			t.Errorf("profile names not sorted: %v", names)
@@ -503,7 +438,6 @@ func TestSetCurrent(t *testing.T) {
 		t.Errorf("expected current='prod', got '%s'", cfg.Current)
 	}
 
-	// Verify it was saved
 	loadedCfg, err := LoadCLIConfig()
 	if err != nil {
 		t.Fatalf("LoadCLIConfig() failed: %v", err)
@@ -511,6 +445,194 @@ func TestSetCurrent(t *testing.T) {
 
 	if loadedCfg.Current != "prod" {
 		t.Errorf("expected saved current='prod', got '%s'", loadedCfg.Current)
+	}
+}
+
+func TestMigrateYAMLConfig(t *testing.T) {
+	tmpDir := t.TempDir()
+	configDir := filepath.Join(tmpDir, ".config", "trino")
+	if err := os.MkdirAll(configDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	yamlData := []byte(`current: default
+profiles:
+  default:
+    host: localhost
+    port: 8080
+    user: testuser
+    password: testpass
+    catalog: test_catalog
+    schema: test_schema
+    ssl:
+      enabled: true
+      insecure: false
+output:
+  format: json
+`)
+	yamlPath := filepath.Join(configDir, "config.yaml")
+	jsonPath := filepath.Join(configDir, "config.json")
+
+	if err := os.WriteFile(yamlPath, yamlData, 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := migrateYAMLConfig(yamlPath, jsonPath)
+	if err != nil {
+		t.Fatalf("migrateYAMLConfig() failed: %v", err)
+	}
+
+	if cfg.Current != "default" {
+		t.Errorf("expected current 'default', got '%s'", cfg.Current)
+	}
+	p, exists := cfg.Profiles["default"]
+	if !exists {
+		t.Fatal("expected 'default' profile")
+	}
+	if p.Host != "localhost" {
+		t.Errorf("expected host 'localhost', got '%s'", p.Host)
+	}
+	if p.Port != 8080 {
+		t.Errorf("expected port 8080, got %d", p.Port)
+	}
+	if p.User != "testuser" {
+		t.Errorf("expected user 'testuser', got '%s'", p.User)
+	}
+	if cfg.Output.Format != "json" {
+		t.Errorf("expected format 'json', got '%s'", cfg.Output.Format)
+	}
+	if p.SSL.Enabled == nil || !*p.SSL.Enabled {
+		t.Error("expected SSL enabled true")
+	}
+
+	// Verify JSON file was created
+	if _, err := os.Stat(jsonPath); os.IsNotExist(err) {
+		t.Error("JSON config file was not created")
+	}
+}
+
+func TestMigrateYAMLConfig_LegacyFlat(t *testing.T) {
+	tmpDir := t.TempDir()
+	configDir := filepath.Join(tmpDir, ".config", "trino")
+	if err := os.MkdirAll(configDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	yamlData := []byte(`trino:
+  host: legacy-host
+  port: 9090
+  user: legacy-user
+output:
+  format: csv
+`)
+	yamlPath := filepath.Join(configDir, "config.yaml")
+	jsonPath := filepath.Join(configDir, "config.json")
+
+	if err := os.WriteFile(yamlPath, yamlData, 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := migrateYAMLConfig(yamlPath, jsonPath)
+	if err != nil {
+		t.Fatalf("migrateYAMLConfig() failed: %v", err)
+	}
+
+	p, exists := cfg.Profiles["default"]
+	if !exists {
+		t.Fatal("expected 'default' profile from legacy migration")
+	}
+	if p.Host != "legacy-host" {
+		t.Errorf("expected host 'legacy-host', got '%s'", p.Host)
+	}
+	if p.Port != 9090 {
+		t.Errorf("expected port 9090, got %d", p.Port)
+	}
+}
+
+func TestLoadCLIConfig_FallbackToYAML(t *testing.T) {
+	tmpDir := t.TempDir()
+	originalHome := os.Getenv("HOME")
+	t.Cleanup(func() {
+		_ = os.Setenv("HOME", originalHome)
+	})
+	_ = os.Setenv("HOME", tmpDir)
+
+	configDir := filepath.Join(tmpDir, ".config", "trino")
+	if err := os.MkdirAll(configDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	yamlData := []byte(`current: default
+profiles:
+  default:
+    host: yaml-host
+    port: 7070
+    user: yaml-user
+`)
+	if err := os.WriteFile(filepath.Join(configDir, "config.yaml"), yamlData, 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := LoadCLIConfig()
+	if err != nil {
+		t.Fatalf("LoadCLIConfig() failed: %v", err)
+	}
+
+	p, exists := cfg.Profiles["default"]
+	if !exists {
+		t.Fatal("expected 'default' profile from YAML fallback")
+	}
+	if p.Host != "yaml-host" {
+		t.Errorf("expected host 'yaml-host', got '%s'", p.Host)
+	}
+
+	// Verify JSON was created (migration happened)
+	jsonPath := filepath.Join(configDir, "config.json")
+	if _, err := os.Stat(jsonPath); os.IsNotExist(err) {
+		t.Error("JSON config was not created during migration")
+	}
+}
+
+func TestMigrateYAMLConfig_FieldsAfterSSL(t *testing.T) {
+	tmpDir := t.TempDir()
+	configDir := filepath.Join(tmpDir, ".config", "trino")
+	if err := os.MkdirAll(configDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Fields after ssl block must be parsed correctly
+	yamlData := []byte(`trino:
+  host: myhost
+  ssl:
+    enabled: true
+    insecure: true
+  user: afterssl
+  catalog: mycat
+`)
+	yamlPath := filepath.Join(configDir, "config.yaml")
+	jsonPath := filepath.Join(configDir, "config.json")
+
+	if err := os.WriteFile(yamlPath, yamlData, 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := migrateYAMLConfig(yamlPath, jsonPath)
+	if err != nil {
+		t.Fatalf("migrateYAMLConfig() failed: %v", err)
+	}
+
+	p := cfg.Profiles["default"]
+	if p.User != "afterssl" {
+		t.Errorf("expected user 'afterssl' (after ssl block), got '%s'", p.User)
+	}
+	if p.Catalog != "mycat" {
+		t.Errorf("expected catalog 'mycat' (after ssl block), got '%s'", p.Catalog)
+	}
+	if p.SSL.Enabled == nil || !*p.SSL.Enabled {
+		t.Error("expected SSL enabled true")
+	}
+	if !p.SSL.Insecure {
+		t.Error("expected SSL insecure true")
 	}
 }
 

--- a/internal/cli/output_test.go
+++ b/internal/cli/output_test.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/tuannvm/mcp-trino/internal/trino"
@@ -9,8 +10,8 @@ import (
 
 func TestOutputTable_DeterministicColumnOrder(t *testing.T) {
 	tests := []struct {
-		name     string
-		rows     []map[string]interface{}
+		name      string
+		rows      []map[string]interface{}
 		truncated bool
 	}{
 		{
@@ -39,24 +40,41 @@ func TestOutputTable_DeterministicColumnOrder(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			cmd := &Commands{format: "table"}
+			cmd, stdout1, _ := newTestCommands(&mockTrinoClient{}, "table")
 			result := &trino.QueryResult{
 				Rows:      tt.rows,
 				Truncated: tt.truncated,
 				MaxRows:   100,
 			}
 
-			// We can't easily capture stdout without refactoring,
-			// but we can verify it doesn't error and runs consistently
 			err := cmd.outputTable(result)
 			if err != nil {
 				t.Errorf("outputTable() failed: %v", err)
 			}
+			output1 := stdout1.String()
 
-			// Run again to verify deterministic output (no panics, same error behavior)
-			err2 := cmd.outputTable(result)
-			if err != err2 {
-				t.Errorf("outputTable() not deterministic: first err=%v, second err=%v", err, err2)
+			// Run again for determinism check
+			cmd2, stdout2, _ := newTestCommands(&mockTrinoClient{}, "table")
+			err2 := cmd2.outputTable(result)
+			if err2 != nil {
+				t.Errorf("outputTable() second run failed: %v", err2)
+			}
+
+			if output1 != stdout2.String() {
+				t.Errorf("outputTable() not deterministic:\nfirst:  %s\nsecond: %s", output1, stdout2.String())
+			}
+
+			// Verify columns are alphabetically sorted
+			lines := strings.Split(output1, "\n")
+			if len(lines) > 0 {
+				header := lines[0]
+				if strings.Contains(header, "zebra") && strings.Contains(header, "apple") {
+					appleIdx := strings.Index(header, "apple")
+					zebraIdx := strings.Index(header, "zebra")
+					if appleIdx > zebraIdx {
+						t.Errorf("columns not sorted alphabetically: %s", header)
+					}
+				}
 			}
 		})
 	}
@@ -64,8 +82,8 @@ func TestOutputTable_DeterministicColumnOrder(t *testing.T) {
 
 func TestOutputCSV_DeterministicColumnOrder(t *testing.T) {
 	tests := []struct {
-		name     string
-		rows     []map[string]interface{}
+		name      string
+		rows      []map[string]interface{}
 		truncated bool
 	}{
 		{
@@ -87,7 +105,7 @@ func TestOutputCSV_DeterministicColumnOrder(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			cmd := &Commands{format: "csv"}
+			cmd, stdout1, _ := newTestCommands(&mockTrinoClient{}, "csv")
 			result := &trino.QueryResult{
 				Rows:      tt.rows,
 				Truncated: tt.truncated,
@@ -98,21 +116,24 @@ func TestOutputCSV_DeterministicColumnOrder(t *testing.T) {
 			if err != nil {
 				t.Errorf("outputCSV() failed: %v", err)
 			}
+			output1 := stdout1.String()
 
-			// Run again to verify deterministic output
-			err2 := cmd.outputCSV(result)
-			if err != err2 {
-				t.Errorf("outputCSV() not deterministic: first err=%v, second err=%v", err, err2)
+			cmd2, stdout2, _ := newTestCommands(&mockTrinoClient{}, "csv")
+			err2 := cmd2.outputCSV(result)
+			if err2 != nil {
+				t.Errorf("outputCSV() second run failed: %v", err2)
+			}
+
+			if output1 != stdout2.String() {
+				t.Errorf("outputCSV() not deterministic:\nfirst:  %s\nsecond: %s", output1, stdout2.String())
 			}
 		})
 	}
 }
 
 func TestOutputJSON_ExactStructure(t *testing.T) {
-	cmd := &Commands{format: "json"}
+	cmd, stdout, _ := newTestCommands(&mockTrinoClient{}, "json")
 
-	// Capture stdout would require refactoring, so we test the error path
-	// and verify the structure is valid by not panicking
 	data := map[string]interface{}{
 		"key1": "value1",
 		"key2": 42,
@@ -123,10 +144,15 @@ func TestOutputJSON_ExactStructure(t *testing.T) {
 	if err != nil {
 		t.Errorf("outputJSON() failed: %v", err)
 	}
+
+	output := stdout.String()
+	if !strings.Contains(output, `"key1"`) || !strings.Contains(output, `"value1"`) {
+		t.Errorf("expected JSON structure, got: %s", output)
+	}
 }
 
 func TestFormatOutput_TableFormat(t *testing.T) {
-	cmd := &Commands{format: "table"}
+	cmd, _, _ := newTestCommands(&mockTrinoClient{}, "table")
 	result := &trino.QueryResult{
 		Rows: []map[string]interface{}{
 			{"col1": "value1", "col2": 123},
@@ -142,7 +168,7 @@ func TestFormatOutput_TableFormat(t *testing.T) {
 }
 
 func TestFormatOutput_CSVFormat(t *testing.T) {
-	cmd := &Commands{format: "csv"}
+	cmd, _, _ := newTestCommands(&mockTrinoClient{}, "csv")
 	result := &trino.QueryResult{
 		Rows: []map[string]interface{}{
 			{"col1": "value1", "col2": 123},
@@ -158,10 +184,7 @@ func TestFormatOutput_CSVFormat(t *testing.T) {
 }
 
 func TestFormatOutput_InvalidFormat(t *testing.T) {
-	// This test verifies that an invalid format doesn't crash
-	// The actual validation happens in cmd/cli.go, so we just test here
-	// that the Commands struct can be created with any format string
-	cmd := &Commands{format: "invalid"}
+	cmd, _, _ := newTestCommands(&mockTrinoClient{}, "invalid")
 	result := &trino.QueryResult{
 		Rows: []map[string]interface{}{
 			{"col1": "value1"},
@@ -170,18 +193,15 @@ func TestFormatOutput_InvalidFormat(t *testing.T) {
 		MaxRows:   100,
 	}
 
-	// This will fall through to outputTable which doesn't validate format
 	err := cmd.formatOutput(result)
-	// We expect this to work (falls back to table format)
 	if err != nil {
 		t.Errorf("formatOutput(invalid) unexpectedly failed: %v", err)
 	}
 }
 
 func TestQueryExecution_OutputFormattingWithMockClient(t *testing.T) {
-	// Test that query execution respects context cancellation
 	ctx, cancel := context.WithCancel(context.Background())
-	cancel() // Cancel immediately
+	cancel()
 
 	client := &mockTrinoClient{
 		queryResult: &trino.QueryResult{
@@ -190,11 +210,8 @@ func TestQueryExecution_OutputFormattingWithMockClient(t *testing.T) {
 			},
 		},
 	}
-	cmd := NewCommands(client, "table")
+	cmd, _, _ := newTestCommands(client, "table")
 
-	// This should handle the cancelled context gracefully
-	// (implementation depends on how ExecuteQueryWithContext handles cancellation)
 	err := cmd.Query(ctx, "SELECT 1")
-	// We don't enforce a specific error behavior, just that it doesn't hang/panic
-	_ = err // Error is acceptable for cancelled context
+	_ = err
 }

--- a/internal/cli/repl.go
+++ b/internal/cli/repl.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"context"
 	"fmt"
+	"io"
 	"os"
 	"strings"
 	"time"
@@ -14,10 +15,16 @@ type REPL struct {
 	commands *Commands
 	scanner  *bufio.Scanner
 	prompt   string
+	out      io.Writer
 }
 
-// NewREPL creates a new interactive REPL session
+// NewREPL creates a new interactive REPL session reading from stdin
 func NewREPL(commands *Commands, catalog, schema string) *REPL {
+	return NewREPLWithReader(commands, catalog, schema, os.Stdin)
+}
+
+// NewREPLWithReader creates a new REPL reading from the given reader
+func NewREPLWithReader(commands *Commands, catalog, schema string, in io.Reader) *REPL {
 	prompt := "trino>"
 	if catalog != "" {
 		if schema != "" {
@@ -29,44 +36,41 @@ func NewREPL(commands *Commands, catalog, schema string) *REPL {
 
 	return &REPL{
 		commands: commands,
-		scanner:  bufio.NewScanner(os.Stdin),
+		scanner:  bufio.NewScanner(in),
 		prompt:   prompt,
+		out:      commands.out,
 	}
 }
 
 // Run starts the interactive REPL loop
 func (r *REPL) Run(ctx context.Context) error {
-	fmt.Println("mcp-trino CLI - Interactive Mode")
-	fmt.Println("Type '\\help' for help, '\\quit' or Ctrl-D to exit")
-	fmt.Println()
+	fmt.Fprintln(r.out, "mcp-trino CLI - Interactive Mode")
+	fmt.Fprintln(r.out, "Type '\\help' for help, '\\quit' or Ctrl-D to exit")
+	fmt.Fprintln(r.out)
 
 	history := []string{}
 
 	for {
-		// Display prompt
-		fmt.Print(r.prompt)
+		fmt.Fprint(r.out, r.prompt)
 
-		// Read input
 		if !r.scanner.Scan() {
-			// EOF (Ctrl-D)
-			fmt.Println()
+			fmt.Fprintln(r.out)
 			return nil
 		}
 
 		line := strings.TrimSpace(r.scanner.Text())
 
-		// Skip empty lines
 		if line == "" {
 			continue
 		}
 
-		// Handle special commands
+		// Handle meta-commands
 		if strings.HasPrefix(line, "\\") {
 			if err := r.handleMetaCommand(ctx, line, &history); err != nil {
 				if err == ErrExitREPL {
 					return nil
 				}
-				fmt.Printf("Error: %v\n", err)
+				fmt.Fprintf(r.commands.errOut, "Error: %v\n", err)
 			}
 			continue
 		}
@@ -74,37 +78,32 @@ func (r *REPL) Run(ctx context.Context) error {
 		// Handle multi-line queries
 		query := line
 		for !strings.HasSuffix(query, ";") && r.hasMoreInput(query) {
-			fmt.Print("... ")
+			fmt.Fprint(r.out, "... ")
 			if !r.scanner.Scan() {
-				// Check for real I/O errors (not just EOF)
 				if err := r.scanner.Err(); err != nil {
 					return fmt.Errorf("multiline input error: %w", err)
 				}
-				// EOF (Ctrl-D) during multiline input - execute what we have
 				break
 			}
 			nextLine := r.scanner.Text()
 			query += "\n" + nextLine
 		}
 
-		// Remove trailing semicolon
 		query = strings.TrimSuffix(query, ";")
 		query = strings.TrimSpace(query)
 
-		// Add to history
 		history = append(history, query)
 
-		// Execute query
 		startTime := time.Now()
 		if err := r.commands.Query(ctx, query); err != nil {
-			fmt.Printf("Error: %v\n", err)
+			fmt.Fprintf(r.commands.errOut, "Error: %v\n", err)
 		} else {
 			duration := time.Since(startTime)
 			if duration > time.Second {
-				fmt.Printf("(%v)\n", duration.Round(time.Millisecond))
+				fmt.Fprintf(r.out, "(%v)\n", duration.Round(time.Millisecond))
 			}
 		}
-		fmt.Println()
+		fmt.Fprintln(r.out)
 	}
 }
 
@@ -151,7 +150,7 @@ func (r *REPL) handleMetaCommand(ctx context.Context, cmd string, history *[]str
 		return r.commands.Describe(ctx, parts[1])
 	case "\\format":
 		if len(parts) < 2 {
-			fmt.Printf("Current format: %s\n", r.commands.format)
+			fmt.Fprintf(r.out, "Current format: %s\n", r.commands.format)
 			return nil
 		}
 		format := strings.ToLower(parts[1])
@@ -159,10 +158,9 @@ func (r *REPL) handleMetaCommand(ctx context.Context, cmd string, history *[]str
 			return fmt.Errorf("invalid format. Supported: table, json, csv")
 		}
 		r.commands.format = format
-		fmt.Printf("Output format set to: %s\n", format)
+		fmt.Fprintf(r.out, "Output format set to: %s\n", format)
 	case "\\timing":
-		// Toggle timing display (for future implementation)
-		fmt.Println("Timing display is always enabled for queries > 1s")
+		fmt.Fprintln(r.out, "Timing display is always enabled for queries > 1s")
 	default:
 		return fmt.Errorf("unknown command: %s (type \\help for available commands)", command)
 	}
@@ -172,16 +170,13 @@ func (r *REPL) handleMetaCommand(ctx context.Context, cmd string, history *[]str
 
 // hasMoreInput checks if there's more input to read (for multi-line queries)
 func (r *REPL) hasMoreInput(query string) bool {
-	// If query ends with semicolon, it's complete
 	query = strings.TrimSpace(query)
 	if strings.HasSuffix(query, ";") {
 		return false
 	}
 
-	// Check for incomplete SQL patterns that require continuation
 	queryLower := strings.ToLower(query)
 
-	// Check if query ends with incomplete keywords (without trailing space after trim)
 	incompleteEnds := []string{
 		"select", "from", "where", "join", "left join",
 		"right join", "inner join", "outer join", "on",
@@ -192,7 +187,6 @@ func (r *REPL) hasMoreInput(query string) bool {
 	}
 
 	for _, end := range incompleteEnds {
-		// Check if query ends with this keyword (as a whole word)
 		if strings.HasSuffix(queryLower, end) {
 			return true
 		}
@@ -203,33 +197,33 @@ func (r *REPL) hasMoreInput(query string) bool {
 
 // printHelp displays help information for REPL commands
 func (r *REPL) printHelp() {
-	fmt.Println("Meta-commands:")
-	fmt.Println("  \\help              Display this help")
-	fmt.Println("  \\quit, \\exit, \\q  Exit the REPL")
-	fmt.Println("  \\history           Display command history")
-	fmt.Println("  \\catalogs          List all catalogs")
-	fmt.Println("  \\schemas [cat]     List schemas (optional catalog)")
-	fmt.Println("  \\tables [cat sch]  List tables (optional catalog.schema)")
-	fmt.Println("  \\describe <table>  Describe table (format: catalog.schema.table)")
-	fmt.Println("  \\format <fmt>      Set output format (table, json, csv)")
-	fmt.Println()
-	fmt.Println("SQL Queries:")
-	fmt.Println("  SELECT ...         Execute a SQL query")
-	fmt.Println("  EXPLAIN ...        Analyze query execution plan")
-	fmt.Println()
-	fmt.Println("Tips:")
-	fmt.Println("  - Use ; to terminate multi-line queries")
-	fmt.Println("  - Ctrl-D exits the REPL")
+	fmt.Fprintln(r.out, "Meta-commands:")
+	fmt.Fprintln(r.out, "  \\help              Display this help")
+	fmt.Fprintln(r.out, "  \\quit, \\exit, \\q  Exit the REPL")
+	fmt.Fprintln(r.out, "  \\history           Display command history")
+	fmt.Fprintln(r.out, "  \\catalogs          List all catalogs")
+	fmt.Fprintln(r.out, "  \\schemas [cat]     List schemas (optional catalog)")
+	fmt.Fprintln(r.out, "  \\tables [cat sch]  List tables (optional catalog.schema)")
+	fmt.Fprintln(r.out, "  \\describe <table>  Describe table (format: catalog.schema.table)")
+	fmt.Fprintln(r.out, "  \\format <fmt>      Set output format (table, json, csv)")
+	fmt.Fprintln(r.out)
+	fmt.Fprintln(r.out, "SQL Queries:")
+	fmt.Fprintln(r.out, "  SELECT ...         Execute a SQL query")
+	fmt.Fprintln(r.out, "  EXPLAIN ...        Analyze query execution plan")
+	fmt.Fprintln(r.out)
+	fmt.Fprintln(r.out, "Tips:")
+	fmt.Fprintln(r.out, "  - Use ; to terminate multi-line queries")
+	fmt.Fprintln(r.out, "  - Ctrl-D exits the REPL")
 }
 
 // printHistory displays command history
 func (r *REPL) printHistory(history *[]string) {
 	if len(*history) == 0 {
-		fmt.Println("No history")
+		fmt.Fprintln(r.out, "No history")
 		return
 	}
 
 	for i, cmd := range *history {
-		fmt.Printf("%4d  %s\n", i+1, cmd)
+		fmt.Fprintf(r.out, "%4d  %s\n", i+1, cmd)
 	}
 }

--- a/internal/cli/repl.go
+++ b/internal/cli/repl.go
@@ -44,17 +44,17 @@ func NewREPLWithReader(commands *Commands, catalog, schema string, in io.Reader)
 
 // Run starts the interactive REPL loop
 func (r *REPL) Run(ctx context.Context) error {
-	fmt.Fprintln(r.out, "mcp-trino CLI - Interactive Mode")
-	fmt.Fprintln(r.out, "Type '\\help' for help, '\\quit' or Ctrl-D to exit")
-	fmt.Fprintln(r.out)
+	_, _ = fmt.Fprintln(r.out, "mcp-trino CLI - Interactive Mode")
+	_, _ = fmt.Fprintln(r.out, "Type '\\help' for help, '\\quit' or Ctrl-D to exit")
+	_, _ = fmt.Fprintln(r.out)
 
 	history := []string{}
 
 	for {
-		fmt.Fprint(r.out, r.prompt)
+		_, _ = fmt.Fprint(r.out, r.prompt)
 
 		if !r.scanner.Scan() {
-			fmt.Fprintln(r.out)
+			_, _ = fmt.Fprintln(r.out)
 			return nil
 		}
 
@@ -70,7 +70,7 @@ func (r *REPL) Run(ctx context.Context) error {
 				if err == ErrExitREPL {
 					return nil
 				}
-				fmt.Fprintf(r.commands.errOut, "Error: %v\n", err)
+				_, _ = fmt.Fprintf(r.commands.errOut, "Error: %v\n", err)
 			}
 			continue
 		}
@@ -78,7 +78,7 @@ func (r *REPL) Run(ctx context.Context) error {
 		// Handle multi-line queries
 		query := line
 		for !strings.HasSuffix(query, ";") && r.hasMoreInput(query) {
-			fmt.Fprint(r.out, "... ")
+			_, _ = fmt.Fprint(r.out, "... ")
 			if !r.scanner.Scan() {
 				if err := r.scanner.Err(); err != nil {
 					return fmt.Errorf("multiline input error: %w", err)
@@ -96,14 +96,14 @@ func (r *REPL) Run(ctx context.Context) error {
 
 		startTime := time.Now()
 		if err := r.commands.Query(ctx, query); err != nil {
-			fmt.Fprintf(r.commands.errOut, "Error: %v\n", err)
+			_, _ = fmt.Fprintf(r.commands.errOut, "Error: %v\n", err)
 		} else {
 			duration := time.Since(startTime)
 			if duration > time.Second {
-				fmt.Fprintf(r.out, "(%v)\n", duration.Round(time.Millisecond))
+				_, _ = fmt.Fprintf(r.out, "(%v)\n", duration.Round(time.Millisecond))
 			}
 		}
-		fmt.Fprintln(r.out)
+		_, _ = fmt.Fprintln(r.out)
 	}
 }
 
@@ -150,7 +150,7 @@ func (r *REPL) handleMetaCommand(ctx context.Context, cmd string, history *[]str
 		return r.commands.Describe(ctx, parts[1])
 	case "\\format":
 		if len(parts) < 2 {
-			fmt.Fprintf(r.out, "Current format: %s\n", r.commands.format)
+			_, _ = fmt.Fprintf(r.out, "Current format: %s\n", r.commands.format)
 			return nil
 		}
 		format := strings.ToLower(parts[1])
@@ -158,9 +158,9 @@ func (r *REPL) handleMetaCommand(ctx context.Context, cmd string, history *[]str
 			return fmt.Errorf("invalid format. Supported: table, json, csv")
 		}
 		r.commands.format = format
-		fmt.Fprintf(r.out, "Output format set to: %s\n", format)
+		_, _ = fmt.Fprintf(r.out, "Output format set to: %s\n", format)
 	case "\\timing":
-		fmt.Fprintln(r.out, "Timing display is always enabled for queries > 1s")
+		_, _ = fmt.Fprintln(r.out, "Timing display is always enabled for queries > 1s")
 	default:
 		return fmt.Errorf("unknown command: %s (type \\help for available commands)", command)
 	}
@@ -197,33 +197,33 @@ func (r *REPL) hasMoreInput(query string) bool {
 
 // printHelp displays help information for REPL commands
 func (r *REPL) printHelp() {
-	fmt.Fprintln(r.out, "Meta-commands:")
-	fmt.Fprintln(r.out, "  \\help              Display this help")
-	fmt.Fprintln(r.out, "  \\quit, \\exit, \\q  Exit the REPL")
-	fmt.Fprintln(r.out, "  \\history           Display command history")
-	fmt.Fprintln(r.out, "  \\catalogs          List all catalogs")
-	fmt.Fprintln(r.out, "  \\schemas [cat]     List schemas (optional catalog)")
-	fmt.Fprintln(r.out, "  \\tables [cat sch]  List tables (optional catalog.schema)")
-	fmt.Fprintln(r.out, "  \\describe <table>  Describe table (format: catalog.schema.table)")
-	fmt.Fprintln(r.out, "  \\format <fmt>      Set output format (table, json, csv)")
-	fmt.Fprintln(r.out)
-	fmt.Fprintln(r.out, "SQL Queries:")
-	fmt.Fprintln(r.out, "  SELECT ...         Execute a SQL query")
-	fmt.Fprintln(r.out, "  EXPLAIN ...        Analyze query execution plan")
-	fmt.Fprintln(r.out)
-	fmt.Fprintln(r.out, "Tips:")
-	fmt.Fprintln(r.out, "  - Use ; to terminate multi-line queries")
-	fmt.Fprintln(r.out, "  - Ctrl-D exits the REPL")
+	_, _ = fmt.Fprintln(r.out, "Meta-commands:")
+	_, _ = fmt.Fprintln(r.out, "  \\help              Display this help")
+	_, _ = fmt.Fprintln(r.out, "  \\quit, \\exit, \\q  Exit the REPL")
+	_, _ = fmt.Fprintln(r.out, "  \\history           Display command history")
+	_, _ = fmt.Fprintln(r.out, "  \\catalogs          List all catalogs")
+	_, _ = fmt.Fprintln(r.out, "  \\schemas [cat]     List schemas (optional catalog)")
+	_, _ = fmt.Fprintln(r.out, "  \\tables [cat sch]  List tables (optional catalog.schema)")
+	_, _ = fmt.Fprintln(r.out, "  \\describe <table>  Describe table (format: catalog.schema.table)")
+	_, _ = fmt.Fprintln(r.out, "  \\format <fmt>      Set output format (table, json, csv)")
+	_, _ = fmt.Fprintln(r.out)
+	_, _ = fmt.Fprintln(r.out, "SQL Queries:")
+	_, _ = fmt.Fprintln(r.out, "  SELECT ...         Execute a SQL query")
+	_, _ = fmt.Fprintln(r.out, "  EXPLAIN ...        Analyze query execution plan")
+	_, _ = fmt.Fprintln(r.out)
+	_, _ = fmt.Fprintln(r.out, "Tips:")
+	_, _ = fmt.Fprintln(r.out, "  - Use ; to terminate multi-line queries")
+	_, _ = fmt.Fprintln(r.out, "  - Ctrl-D exits the REPL")
 }
 
 // printHistory displays command history
 func (r *REPL) printHistory(history *[]string) {
 	if len(*history) == 0 {
-		fmt.Fprintln(r.out, "No history")
+		_, _ = fmt.Fprintln(r.out, "No history")
 		return
 	}
 
 	for i, cmd := range *history {
-		fmt.Fprintf(r.out, "%4d  %s\n", i+1, cmd)
+		_, _ = fmt.Fprintf(r.out, "%4d  %s\n", i+1, cmd)
 	}
 }

--- a/internal/cli/repl.go
+++ b/internal/cli/repl.go
@@ -54,6 +54,9 @@ func (r *REPL) Run(ctx context.Context) error {
 		_, _ = fmt.Fprint(r.out, r.prompt)
 
 		if !r.scanner.Scan() {
+			if err := r.scanner.Err(); err != nil {
+				return fmt.Errorf("input error: %w", err)
+			}
 			_, _ = fmt.Fprintln(r.out)
 			return nil
 		}

--- a/internal/cli/repl_test.go
+++ b/internal/cli/repl_test.go
@@ -1,12 +1,18 @@
 package cli
 
 import (
+	"bytes"
+	"context"
+	"strings"
 	"testing"
+
+	"github.com/tuannvm/mcp-trino/internal/trino"
 )
 
 func TestNewREPL(t *testing.T) {
 	mockClient := &mockTrinoClient{}
-	cmd := NewCommands(mockClient, "table")
+	var buf bytes.Buffer
+	cmd := NewCommandsWithWriters(mockClient, "table", &buf, &buf)
 
 	repl := NewREPL(cmd, "memory", "default")
 
@@ -20,7 +26,8 @@ func TestNewREPL(t *testing.T) {
 
 func TestNewREPL_EmptyCatalogSchema(t *testing.T) {
 	mockClient := &mockTrinoClient{}
-	cmd := NewCommands(mockClient, "table")
+	var buf bytes.Buffer
+	cmd := NewCommandsWithWriters(mockClient, "table", &buf, &buf)
 
 	repl := NewREPL(cmd, "", "")
 
@@ -31,7 +38,8 @@ func TestNewREPL_EmptyCatalogSchema(t *testing.T) {
 
 func TestNewREPL_CatalogOnly_NoSchema(t *testing.T) {
 	mockClient := &mockTrinoClient{}
-	cmd := NewCommands(mockClient, "table")
+	var buf bytes.Buffer
+	cmd := NewCommandsWithWriters(mockClient, "table", &buf, &buf)
 
 	repl := NewREPL(cmd, "memory", "")
 
@@ -42,7 +50,8 @@ func TestNewREPL_CatalogOnly_NoSchema(t *testing.T) {
 
 func TestNewREPL_CatalogAndSchema(t *testing.T) {
 	mockClient := &mockTrinoClient{}
-	cmd := NewCommands(mockClient, "table")
+	var buf bytes.Buffer
+	cmd := NewCommandsWithWriters(mockClient, "table", &buf, &buf)
 
 	repl := NewREPL(cmd, "memory", "default")
 
@@ -117,23 +126,85 @@ func TestHasMoreInput(t *testing.T) {
 }
 
 func TestREPL_PrintHelp(t *testing.T) {
-	repl := &REPL{}
-	// Just verify it doesn't panic
+	var buf bytes.Buffer
+	repl := &REPL{out: &buf}
 	repl.printHelp()
+
+	output := buf.String()
+	if !strings.Contains(output, "Meta-commands") {
+		t.Errorf("expected help text, got: %s", output)
+	}
 }
 
 func TestREPL_PrintHistory_Empty(t *testing.T) {
-	repl := &REPL{}
+	var buf bytes.Buffer
+	repl := &REPL{out: &buf}
 	history := []string{}
 
-	// Just verify it doesn't panic
 	repl.printHistory(&history)
+
+	if !strings.Contains(buf.String(), "No history") {
+		t.Errorf("expected 'No history', got: %s", buf.String())
+	}
+}
+
+func TestREPL_RunWithInput(t *testing.T) {
+	client := &mockTrinoClient{
+		catalogs: []string{"cat1", "cat2"},
+	}
+	var stdout, stderr bytes.Buffer
+	cmd := NewCommandsWithWriters(client, "table", &stdout, &stderr)
+
+	input := strings.NewReader("\\catalogs\n\\quit\n")
+	repl := NewREPLWithReader(cmd, "", "", input)
+
+	ctx := context.Background()
+	err := repl.Run(ctx)
+	if err != nil {
+		t.Fatalf("REPL.Run() failed: %v", err)
+	}
+
+	output := stdout.String()
+	if !strings.Contains(output, "cat1") {
+		t.Errorf("expected catalogs in output, got: %s", output)
+	}
+}
+
+func TestREPL_RunQuery(t *testing.T) {
+	client := &mockTrinoClient{
+		queryResult: &trino.QueryResult{
+			Rows: []map[string]interface{}{
+				{"val": 42},
+			},
+			MaxRows: 10000,
+		},
+	}
+	var stdout, stderr bytes.Buffer
+	cmd := NewCommandsWithWriters(client, "table", &stdout, &stderr)
+
+	input := strings.NewReader("SELECT 42;\n\\quit\n")
+	repl := NewREPLWithReader(cmd, "", "", input)
+
+	err := repl.Run(context.Background())
+	if err != nil {
+		t.Fatalf("REPL.Run() failed: %v", err)
+	}
+
+	output := stdout.String()
+	if !strings.Contains(output, "42") {
+		t.Errorf("expected query result in output, got: %s", output)
+	}
 }
 
 func TestREPL_PrintHistory_WithItems(t *testing.T) {
-	repl := &REPL{}
+	var buf bytes.Buffer
+	repl := &REPL{out: &buf}
 	history := []string{"SELECT 1", "SELECT 2", "SELECT 3"}
 
-	// Just verify it doesn't panic
 	repl.printHistory(&history)
+
+	output := buf.String()
+	if !strings.Contains(output, "SELECT 1") || !strings.Contains(output, "SELECT 3") {
+		t.Errorf("expected history items in output, got: %s", output)
+	}
 }

--- a/internal/cli/repl_test.go
+++ b/internal/cli/repl_test.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -193,6 +194,100 @@ func TestREPL_RunQuery(t *testing.T) {
 	output := stdout.String()
 	if !strings.Contains(output, "42") {
 		t.Errorf("expected query result in output, got: %s", output)
+	}
+}
+
+func TestREPL_QueryError_ToStderr(t *testing.T) {
+	client := &mockTrinoClient{
+		queryError: fmt.Errorf("connection refused"),
+	}
+	var stdout, stderr bytes.Buffer
+	cmd := NewCommandsWithWriters(client, "table", &stdout, &stderr)
+
+	input := strings.NewReader("SELECT 1;\n\\quit\n")
+	repl := NewREPLWithReader(cmd, "", "", input)
+
+	err := repl.Run(context.Background())
+	if err != nil {
+		t.Fatalf("REPL.Run() failed: %v", err)
+	}
+
+	if !strings.Contains(stderr.String(), "connection refused") {
+		t.Errorf("expected error on stderr, got stdout=%q stderr=%q", stdout.String(), stderr.String())
+	}
+	// Error should NOT appear on stdout
+	if strings.Contains(stdout.String(), "connection refused") {
+		t.Error("error message should not appear on stdout")
+	}
+}
+
+func TestREPL_MetaCommandError_ToStderr(t *testing.T) {
+	client := &mockTrinoClient{}
+	var stdout, stderr bytes.Buffer
+	cmd := NewCommandsWithWriters(client, "table", &stdout, &stderr)
+
+	input := strings.NewReader("\\describe\n\\quit\n")
+	repl := NewREPLWithReader(cmd, "", "", input)
+
+	err := repl.Run(context.Background())
+	if err != nil {
+		t.Fatalf("REPL.Run() failed: %v", err)
+	}
+
+	if !strings.Contains(stderr.String(), "usage:") {
+		t.Errorf("expected usage error on stderr, got stderr=%q", stderr.String())
+	}
+}
+
+func TestREPL_FormatCommand(t *testing.T) {
+	client := &mockTrinoClient{}
+	var stdout, stderr bytes.Buffer
+	cmd := NewCommandsWithWriters(client, "table", &stdout, &stderr)
+
+	input := strings.NewReader("\\format json\n\\format\n\\quit\n")
+	repl := NewREPLWithReader(cmd, "", "", input)
+
+	err := repl.Run(context.Background())
+	if err != nil {
+		t.Fatalf("REPL.Run() failed: %v", err)
+	}
+
+	output := stdout.String()
+	if !strings.Contains(output, "Output format set to: json") {
+		t.Errorf("expected format change confirmation, got: %s", output)
+	}
+	if !strings.Contains(output, "Current format: json") {
+		t.Errorf("expected current format display, got: %s", output)
+	}
+}
+
+func TestREPL_InvalidFormatCommand(t *testing.T) {
+	client := &mockTrinoClient{}
+	var stdout, stderr bytes.Buffer
+	cmd := NewCommandsWithWriters(client, "table", &stdout, &stderr)
+
+	input := strings.NewReader("\\format xml\n\\quit\n")
+	repl := NewREPLWithReader(cmd, "", "", input)
+
+	_ = repl.Run(context.Background())
+
+	if !strings.Contains(stderr.String(), "invalid format") {
+		t.Errorf("expected 'invalid format' on stderr, got: %s", stderr.String())
+	}
+}
+
+func TestREPL_EOF_GracefulExit(t *testing.T) {
+	client := &mockTrinoClient{}
+	var stdout, stderr bytes.Buffer
+	cmd := NewCommandsWithWriters(client, "table", &stdout, &stderr)
+
+	// Empty input = immediate EOF
+	input := strings.NewReader("")
+	repl := NewREPLWithReader(cmd, "", "", input)
+
+	err := repl.Run(context.Background())
+	if err != nil {
+		t.Fatalf("REPL.Run() should exit gracefully on EOF, got: %v", err)
 	}
 }
 


### PR DESCRIPTION
- Replace gopkg.in/yaml.v3 with encoding/json for config (config.json)
- Auto-migrate legacy YAML configs to JSON on first load
- Use text/tabwriter for table output, encoding/csv for CSV output
- Inject io.Writer/io.Reader for full testability (Commands, REPL)
- Structured --help with NAME/SYNOPSIS/DESCRIPTION/COMMANDS/FLAGS/EXAMPLES/ENVIRONMENT
- Per-subcommand --help (e.g. mcp-trino query --help)
- Unix exit codes: 0 success, 1 error, 2 usage error
- Signal handling via signal.NotifyContext (SIGINT/SIGTERM)
- Errors to stderr, data to stdout
- No third-party library imports in cli package

## Summary
<!-- What does this PR do? -->

## Changes
-

## Testing
- [ ] Tests pass locally
- [ ] New tests added (if applicable)

## Related Issues
<!-- Fixes #123 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configuration supports both JSON and YAML with automatic format detection and JSON-first precedence
  * CLI and REPL output can be directed to custom streams for better testability and piping

* **Bug Fixes**
  * Deterministic column ordering and corrected CSV/table output alignment and flush behavior

* **Improvements**
  * Structured, per-command help (NAME/SYNOPSIS/etc.)
  * CLI errors printed to stderr with explicit exit codes; signal-aware shutdown handling

* **Documentation**
  * Updated docs and README to reflect new help, config formats, and exit semantics
<!-- end of auto-generated comment: release notes by coderabbit.ai -->